### PR TITLE
Improve `dotnet watch` functionality

### DIFF
--- a/eng/pnpm.targets
+++ b/eng/pnpm.targets
@@ -14,12 +14,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Include="src/**" />
+        <Compile Include="src/**" Watch="false" />
         <RestoreConfig Include="$(SolutionRoot)package.json" />
         <RestoreConfig Include="$(SolutionRoot)pnpm-lock.yaml" />
         <RestoreConfig Include="package.json" />
         <CompileConfig Include="tsconfig*.json" />
         <CompileConfig Include="rollup.config*.json" />
+        <Watch Include="@(RestoreConfig)" />
 
         <PnpmPackagedFiles Condition=" '$(PnpmPackagedFiles)' == '' " Include="@(CompileConfig)" />
         <PnpmPackagedFiles Include=".npmignore" />

--- a/ui/Ui.esproj
+++ b/ui/Ui.esproj
@@ -8,13 +8,13 @@
 	<Import Project="$(RepositoryEngineeringDir)pnpm.targets" />
 
 	<ItemGroup>
-		<Compile Include="vite.config.ts" />
+		<Compile Include="vite.config.ts" Watch="false" />
 		<Compile Include="public/**/*" />
 		<Compile Remove="src/**/stories/**/*;src/**/*.stories.*" />
 		<Watch Include="$(SolutionRoot)schemas/**/*" />
 
 		<CompileOutputs Include="$(ViteBuildDir)\index.html" />
-		
+
 		<Clean Include="$(ViteBuildDir)**/*" Exclude="$(ViteBuildDir).gitkeep" />
 		<Clean Include="src/generated/api/**/*" />
 	</ItemGroup>


### PR DESCRIPTION
- Excludes source files from UI project's `dotnet watch --list`, which prevents unnecessary restarts of the vite server.
- Adds package files that are used to inform when a restore needs to happen for the UI project to cause reloads on branch changes