### PR TITLE
Correct PowerShell exit code checking

### DIFF
--- a/Server.Tests/Git/ToolsCommands/GitUpstreamDataShould.cs
+++ b/Server.Tests/Git/ToolsCommands/GitUpstreamDataShould.cs
@@ -88,6 +88,7 @@ public class GitUpstreamDataShould
 		return target.Verifiable(
 			ps => ps.InvokeCliAsync("git", "ls-tree", "-r", "refs/remotes/origin/_upstream", "--format=%(objectname) %(path)"),
 			s => s.ReturnsAsync(PowerShellInvocationResultStubs.WithCliErrors(
+				128,
 				"fatal: Not a valid object name refs/remotes/origin/_upstream"
 			))
 		);

--- a/Server.Tests/ShellUtilities/PowerShellInvocationResultStubs.cs
+++ b/Server.Tests/ShellUtilities/PowerShellInvocationResultStubs.cs
@@ -10,8 +10,8 @@ public static class PowerShellInvocationResultStubs
 		Results: Array.Empty<PSObject>(),
 		InvocationState: PSInvocationState.Completed,
 		InvocationStateException: null,
-		HadErrors: false,
-		ErrorContents: Array.Empty<PSObject>(),
+		LastExitCode: 0,
+		LastError: null,
 		Streams: new(
 			Debug: Array.Empty<DebugRecord>(),
 			Verbose: Array.Empty<VerboseRecord>(),
@@ -28,10 +28,10 @@ public static class PowerShellInvocationResultStubs
 			Results = lines.Select(line => new PSObject(line)).ToArray()
 		};
 
-	public static PowerShellInvocationResult WithCliErrors(params string[] lines) =>
+	public static PowerShellInvocationResult WithCliErrors(int exitCode, params string[] lines) =>
 		Empty with
 		{
-			HadErrors = true,
+			LastExitCode = exitCode,
 			Streams = Empty.Streams with
 			{
 				Error = (

--- a/Server.Tests/ShellUtilities/PowershellScriptingShould.cs
+++ b/Server.Tests/ShellUtilities/PowershellScriptingShould.cs
@@ -148,6 +148,29 @@ public class PowershellScriptingShould
 		Assert.Equal(2, parameters.Count);
 	}
 
+	[Fact]
+	public async Task Returns_errors_if_exit_code_is_non_zero()
+	{
+		// When types are left off of the parameter, ensures the same types are passed back to the calling app, at least within JSON.
+		using var ps = psFactory.Create();
+
+		var invocationResult = await InvokeInvalidCliCommand(ps);
+
+		Assert.True(invocationResult.HadErrors);
+	}
+
+	[Fact]
+	public async Task Returns_no_error_if_exit_code_is_later_zero_again()
+	{
+		// When types are left off of the parameter, ensures the same types are passed back to the calling app, at least within JSON.
+		using var ps = psFactory.Create();
+
+		await InvokeInvalidCliCommand(ps);
+		var invocationResult = await InvokeValidCliCommand(ps);
+
+		Assert.False(invocationResult.HadErrors);
+	}
+
 	private static JsonObject GetReturnedPSBoundParameters(PowerShellInvocationResult result)
 	{
 		var writeHostResult = Assert.IsType<HostInformationMessage>(result.Streams.Information.SingleOrDefault()?.MessageData).Message;
@@ -165,4 +188,15 @@ public class PowershellScriptingShould
 	{
 		shell.AddParameter("required", defaultRequiredValue);
 	}
+
+	private static Task<PowerShellInvocationResult> InvokeInvalidCliCommand(IPowerShell ps)
+	{
+		return ps.InvokeCliAsync("git", "--not-a-valid-option");
+	}
+
+	private static Task<PowerShellInvocationResult> InvokeValidCliCommand(IPowerShell ps)
+	{
+		return ps.InvokeCliAsync("git", "--version");
+	}
+
 }


### PR DESCRIPTION
The `HadErrors` property on the `PowerShell` class only reports if any of the scripts output to the error stream - and does not clear on subsequent invocations.

This also adds an actual test for this case that uses `git --not-a-valid-option` to get a non-zero exit code and `git --version` to get a zero exit code.