### PR TITLE
Allow for smaller visualizations

### DIFF
--- a/ui/src/components/branch-graph/branch-graph.presentation.tsx
+++ b/ui/src/components/branch-graph/branch-graph.presentation.tsx
@@ -3,7 +3,6 @@ import { FullSizeSvg } from '../svg/full-size-svg';
 import { useBranchSimulation } from './branch-graph.simulation';
 import { BranchLink } from './BranchLink';
 import { BranchNode } from './BranchNode';
-import { CenterG } from './CenterG';
 import type { Branch, BranchConfiguration } from '../../generated/api/models';
 
 export type BranchGraphPresentationProps = {
@@ -16,24 +15,25 @@ export function BranchGraphPresentation({
 	onClick,
 }: BranchGraphPresentationProps) {
 	const [sizeDetection, size] = useResizeDetector<SVGSVGElement>();
-	const { nodes, links, restartSimulation } = useBranchSimulation(upstreamData);
+	const { nodes, links, restartSimulation } = useBranchSimulation(
+		upstreamData,
+		size,
+	);
 
 	return (
 		<section>
 			<FullSizeSvg ref={sizeDetection}>
-				<CenterG size={size}>
-					{links.map((link) => (
-						<BranchLink key={link.id} link={link} />
-					))}
-					{nodes.map((node) => (
-						<BranchNode
-							key={node.id}
-							node={node}
-							onMove={restartSimulation}
-							onClick={onClick && (() => onClick(node.data))}
-						/>
-					))}
-				</CenterG>
+				{links.map((link) => (
+					<BranchLink key={link.id} link={link} />
+				))}
+				{nodes.map((node) => (
+					<BranchNode
+						key={node.id}
+						node={node}
+						onMove={restartSimulation}
+						onClick={onClick && (() => onClick(node.data))}
+					/>
+				))}
 			</FullSizeSvg>
 		</section>
 	);

--- a/ui/src/components/branch-graph/branch-graph.simulation.tsx
+++ b/ui/src/components/branch-graph/branch-graph.simulation.tsx
@@ -69,6 +69,13 @@ function resettableMemo<TInput, TOutput>(toOutput: (input: TInput) => TOutput) {
 	};
 }
 
+function average(values: number[]): number {
+	if (values.length === 0) return NaN;
+	return values
+		.map((v) => v / values.length)
+		.reduce((prev, next) => prev + next, 0);
+}
+
 function forceHierarchy(depthDistance: number) {
 	let currentNodes: WithAtom<BranchGraphNodeDatum>[] = [];
 	let links: WithAtom<BranchGraphLinkDatum>[] = [];
@@ -88,25 +95,12 @@ function forceHierarchy(depthDistance: number) {
 				Math.min(...upstream.map(toX).filter(isNumber)) - depthDistance,
 			].filter(isNotInfinity);
 			if (range.length === 0) return;
-			const targetX = range.reduce(
-				(prev, next) => prev + next / range.length,
-				0,
-			);
+			const targetX = average(range);
 
 			const currentX = node.x ?? 0;
 			const delta = targetX - currentX;
 			const amount = delta * alpha * (downstream.length + upstream.length);
 			node.vx = (node.vx ?? 0) + amount;
-			if (amount > 0)
-				for (const other of downstream) {
-					if (typeof other.fx !== 'number') continue;
-					other.vx = (other.vx ?? 0) - amount;
-				}
-			if (amount < 0)
-				for (const other of upstream) {
-					if (typeof other.fx !== 'number') continue;
-					other.vx = (other.vx ?? 0) - amount;
-				}
 		}
 	}
 	return Object.assign(update, {
@@ -130,7 +124,7 @@ export function useBranchSimulation<T extends BranchConfiguration>(
 			[],
 		)
 			.distance(40)
-			.strength(0.9),
+			.strength(0.5),
 	);
 	const hierarchyForce = useRef(forceHierarchy(40));
 	const simulationRef = useRef<BranchSimulation>();

--- a/ui/src/components/branch-graph/forceWithinBoundaries.test.ts
+++ b/ui/src/components/branch-graph/forceWithinBoundaries.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { toOffsetScale } from './forceWithinBoundaries';
+
+describe('toOffsetScale', () => {
+	it('keeps target above min', () => {
+		const [actualOffset, actualScale] = toOffsetScale(-100, 100, 300, 0);
+		expect(actualOffset).toBe(100);
+		expect(actualScale).toBe(1);
+	});
+
+	it('adjusts scale', () => {
+		const [actualOffset, actualScale] = toOffsetScale(0, 400, 300, 0);
+		expect(actualOffset).toBe(0);
+		expect(actualScale).toBe(0.75);
+	});
+
+	it('keeps target below max', () => {
+		const [actualOffset, actualScale] = toOffsetScale(200, 400, 300, 0);
+		expect(actualOffset).toBe(-100);
+		expect(actualScale).toBe(1);
+	});
+
+	it('adjusts position and scale', () => {
+		const [actualOffset, actualScale] = toOffsetScale(-100, 400, 300, 0);
+		expect(actualOffset).toBe(60);
+		expect(actualScale).toBe(0.6);
+	});
+});

--- a/ui/src/components/branch-graph/forceWithinBoundaries.tsx
+++ b/ui/src/components/branch-graph/forceWithinBoundaries.tsx
@@ -1,0 +1,46 @@
+import { isNumber } from '../../utils/isNumber';
+import type { ElementDimensions } from '../../utils/atoms/useResizeDetector';
+import type { SimulationNodeDatum } from 'd3-force';
+
+export function forceWithinBoundaries<TNode extends SimulationNodeDatum>(
+	getSize: () => ElementDimensions,
+	inset: number = 0,
+) {
+	let nodes: TNode[] = [];
+	function update() {
+		const { width = 0, height = 0 } = getSize();
+
+		const minX = Math.min(...nodes.map((n) => n.x).filter(isNumber));
+		const maxX = Math.max(...nodes.map((n) => n.x).filter(isNumber));
+		const [offsetX, scaleX] = toOffsetScale(minX, maxX, width);
+
+		const minY = Math.min(...nodes.map((n) => n.y).filter(isNumber));
+		const maxY = Math.max(...nodes.map((n) => n.y).filter(isNumber));
+		const [offsetY, scaleY] = toOffsetScale(minY, maxY, height);
+
+		for (const node of nodes) {
+			if (isNumber(node.x)) node.x = node.x * scaleX + offsetX;
+			if (isNumber(node.y)) node.y = node.y * scaleY + offsetY;
+		}
+	}
+	return Object.assign(update, {
+		initialize(newNodes: TNode[]) {
+			nodes = newNodes;
+		},
+	});
+
+	function toOffsetScale(
+		min: number,
+		max: number,
+		targetRange: number,
+	): [offset: number, scale: number] {
+		const actualRange = max - min;
+
+		if (actualRange === Number.POSITIVE_INFINITY || targetRange <= 0)
+			return [0, 1];
+		return [
+			Math.max(0, 0 - min + inset),
+			Math.min(1, (targetRange - inset * 2) / actualRange),
+		];
+	}
+}

--- a/ui/src/pages/branch-details/index.tsx
+++ b/ui/src/pages/branch-details/index.tsx
@@ -1,12 +1,18 @@
 import { useNavigate } from 'react-router-dom';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+	useQueryClient,
+	useSuspenseQueries,
+	useQueries,
+} from '@tanstack/react-query';
 import { BranchGraphPresentation } from '../../components/branch-graph/branch-graph.presentation';
 import { Container } from '../../components/common';
 import { queries } from '../../utils/api/queries';
+import { getBranchDetails } from '../../utils/api/queries/git/branch-details';
+import type { BranchDetails } from '../../generated/api/models';
 
 export function BranchDetailsComponent({ name }: { name: string[] }) {
 	const navigate = useNavigate();
-	const response = useSuspenseQuery(queries.getBranchDetails(name)).data;
+	const response = useBranchDetails(name);
 	return (
 		<Container.Full>
 			<BranchGraphPresentation
@@ -15,4 +21,70 @@ export function BranchDetailsComponent({ name }: { name: string[] }) {
 			/>
 		</Container.Full>
 	);
+}
+
+function useBranchDetails(names: string[]) {
+	const queryClient = useQueryClient();
+
+	useSuspenseQueries({
+		queries: names.map(getBranchDetails),
+	});
+
+	const currentResults = getRelevantBranchNames(names, getDetails);
+	const result = useQueries({
+		queries: currentResults.map(getBranchDetails),
+	});
+	return result
+		.filter((r): r is typeof r & { isSuccess: true } => r.isSuccess)
+		.map((r) => r.data);
+
+	function getDetails(name: string) {
+		return queryClient.getQueryData<BranchDetails>(
+			queries.getBranchDetails(name).queryKey,
+		);
+	}
+}
+
+function getRelevantBranchNames(
+	names: string[],
+	getDetails: (branch: string) => BranchDetails | undefined,
+) {
+	return [
+		...names,
+		...expandBranches(names, getUpstreamBranchNames(getDetails)),
+		...expandBranches(names, getDownstreamBranchNames(getDetails)),
+	];
+}
+
+function getUpstreamBranchNames(
+	getDetails: (branch: string) => BranchDetails | undefined,
+) {
+	return (current: string) =>
+		getDetails(current)?.upstream.map((b) => b.name) ?? [];
+}
+
+function getDownstreamBranchNames(
+	getDetails: (branch: string) => BranchDetails | undefined,
+) {
+	return (current: string) =>
+		getDetails(current)?.downstream.map((b) => b.name) ?? [];
+}
+
+function expandBranches(
+	branchNames: string[],
+	getMore: (name: string) => string[],
+) {
+	const result = new Set<string>(branchNames);
+	const stack = [...branchNames];
+	let current: string | undefined;
+	while ((current = stack.pop())) {
+		const adding = getMore(current);
+
+		for (const entry of adding) {
+			if (result.has(entry)) continue;
+			result.add(entry);
+			stack.push(entry);
+		}
+	}
+	return Array.from(result.values());
 }

--- a/ui/src/utils/api/queries/git/branch-details.ts
+++ b/ui/src/utils/api/queries/git/branch-details.ts
@@ -1,17 +1,17 @@
 import { api } from '../../fetch-api';
 
-export const getBranchDetails = (branchNames: string[]) => ({
-	queryKey: ['branch-details', branchNames],
+export const getBranchDetails = (branchName: string) => ({
+	queryKey: ['branch-details', branchName],
 	queryFn: async () => {
 		const response = await api.getBranchDetails({
 			body: {
-				branches: branchNames,
-				includeDownstream: true,
-				includeUpstream: true,
-				recurse: true,
+				branches: [branchName],
+				includeDownstream: false,
+				includeUpstream: false,
+				recurse: false,
 			},
 		});
 		if (response.statusCode !== 200) return Promise.reject(response);
-		return response.data;
+		return response.data[0];
 	},
 });

--- a/ui/src/utils/isNumber.ts
+++ b/ui/src/utils/isNumber.ts
@@ -1,0 +1,3 @@
+export function isNumber(n: number | null | undefined): n is number {
+	return typeof n === 'number';
+}


### PR DESCRIPTION
While the visualizations aren't currently used in a smaller-than-fullscreen setup currently, these changes to the visualization:
* improve expectation matching with interactions
* keeps the visualization within the SVG boundaries set
* simplifies logic of hierarchical force