### PR TITLE
Add .env files to watch list

### DIFF
--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -47,6 +47,8 @@
 
   <ItemGroup>
     <OpenApiSchemaMvcServer Include="..\schemas\api.yaml" Link="Api\api.yaml" />
+    <Watch Include=".env" />
+    <Watch Include="../.env" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Quality-of-life developer experience change so that `dotnet watch` restarts when environment variables are changed, which allows for easy switching between displayed repositories.