### PR TITLE
Refresh via UI

### DIFF
--- a/Server.Tests/Git/ToolsCommands/GitFetchShould.cs
+++ b/Server.Tests/Git/ToolsCommands/GitFetchShould.cs
@@ -22,7 +22,7 @@ public class GitFetchShould
 	internal static VerifiableMock<IPowerShellCommandContext, Task<PowerShellInvocationResult>> SetupGitFetch(Mock<IPowerShellCommandContext> target)
 	{
 		return target.Verifiable(
-			ps => ps.PowerShellInvoker.InvokeCliAsync("git", "fetch", "--porcelain"),
+			ps => ps.PowerShellInvoker.InvokeCliAsync("git", "fetch", "--porcelain", "--prune"),
 			s => s.ReturnsAsync(PowerShellInvocationResultStubs.Empty)
 		);
 	}

--- a/Server/Git/ToolsCommands/GitFetch.cs
+++ b/Server/Git/ToolsCommands/GitFetch.cs
@@ -10,6 +10,6 @@ public record GitFetch() : IPowerShellCommand<Task>
 {
 	public async Task RunCommand(IPowerShellCommandContext pwsh)
 	{
-		(await pwsh.InvokeCliAsync("git", "fetch", "--porcelain")).ThrowIfHadErrors();
+		(await pwsh.InvokeCliAsync("git", "fetch", "--porcelain", "--prune")).ThrowIfHadErrors();
 	}
 }

--- a/ui/src/components/common/button.tsx
+++ b/ui/src/components/common/button.tsx
@@ -1,0 +1,32 @@
+import { twMerge } from 'tailwind-merge';
+import { elementTemplate } from '../templating';
+
+/** Not intended for use as a component (though it could be), this is intended
+ * more as a template for a base `button` that moves the "disabled"
+ * functionality to a more appropriate location and applies a base style. */
+const disabledButtonTemplate = elementTemplate(
+	'disabledButton',
+	'button',
+	(T) => <T type="button" />,
+	{
+		useProps: ({ className, disabled, ...rest }) => ({
+			disabled: false,
+			className: twMerge(disabled && 'opacity-20', className),
+			...rest,
+		}),
+	},
+);
+
+export const Button = disabledButtonTemplate.extend('Button', (T) => (
+	<T
+		className={twMerge(
+			'bg-slate-800 text-white focus:bg-slate-700 hover:bg-slate-700 outline-black',
+			'dark:bg-slate-100 dark:text-slate-900 dark:focus:bg-slate-200 dark:hover:bg-slate-200 dark:outline-white',
+			'px-3 py-2 rounded-md',
+			'w-full sm:w-auto',
+			'inline-flex items-center justify-center',
+			'text-sm font-semibold',
+			'transition-colors shadow-sm',
+		)}
+	/>
+));

--- a/ui/src/components/common/index.tsx
+++ b/ui/src/components/common/index.tsx
@@ -1,3 +1,4 @@
+export * from './button';
 export * from './container';
 export * from './InlineText';
 export * from './list';

--- a/ui/src/components/layout/header.container.tsx
+++ b/ui/src/components/layout/header.container.tsx
@@ -18,7 +18,7 @@ export function useHeader(): React.ComponentType<HeaderPresentationalProps> {
 			return (
 				<HeaderPresentation
 					{...props}
-					onRefresh={fetch.mutate}
+					onRefresh={() => !fetch.isPending && fetch.mutate()}
 					isRefreshing={fetch.isPending}
 				/>
 			);

--- a/ui/src/components/layout/header.container.tsx
+++ b/ui/src/components/layout/header.container.tsx
@@ -1,6 +1,28 @@
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queries } from '../../utils/api/queries';
 import { HeaderPresentation } from './header.presentation';
-import type { HeaderProps } from './header.presentation';
+import type { HeaderPresentationalProps } from './header.presentation';
 
-export function useHeader(): React.ComponentType<HeaderProps> {
-	return HeaderPresentation;
+export function useHeader(): React.ComponentType<HeaderPresentationalProps> {
+	const queryClient = useQueryClient();
+
+	return useCallback(
+		function HeaderContainer(props: HeaderPresentationalProps) {
+			const fetch = useMutation({
+				...queries.requestGitFetch,
+				onSuccess: async () => {
+					await queryClient.invalidateQueries();
+				},
+			});
+			return (
+				<HeaderPresentation
+					{...props}
+					onRefresh={fetch.mutate}
+					isRefreshing={fetch.isPending}
+				/>
+			);
+		},
+		[queryClient],
+	);
 }

--- a/ui/src/components/layout/header.presentation.tsx
+++ b/ui/src/components/layout/header.presentation.tsx
@@ -1,22 +1,31 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { twMerge } from 'tailwind-merge';
+import { Button } from '../common';
+import { elementTemplate } from '../templating';
 import styles from './layout.module.css';
 
-export type HeaderProps = {
+export type HeaderPresentationalProps = {
 	/* This type intentionally blank */
 };
 
-export function HeaderPresentation(/* {}: HeaderProps */) {
+export type HeaderProps = HeaderPresentationalProps & {
+	isRefreshing: boolean;
+	onRefresh: () => void;
+};
+
+const Header = elementTemplate('Header', 'header', (T) => (
+	<T className="bg-slate-200 text-slate-900 dark:bg-slate-800 dark:text-white shadow-sm flex flex-row items-center gap-4 h-12 p-1" />
+));
+
+export function HeaderPresentation({ isRefreshing, onRefresh }: HeaderProps) {
 	const { t } = useTranslation(['app']);
 	return (
-		<header
-			className={twMerge(
-				styles.header,
-				'bg-slate-200 text-slate-900 dark:bg-slate-800 dark:text-white shadow-sm flex flex-row items-center gap-4 h-12 p-1',
-			)}
-		>
+		<Header className={styles.header}>
 			<Link to="/">{t('title')}</Link>
-		</header>
+			<span className="flex-grow" />
+			<Button onClick={onRefresh} disabled={isRefreshing}>
+				{t('refresh')}
+			</Button>
+		</Header>
 	);
 }

--- a/ui/src/components/layout/header.stories.tsx
+++ b/ui/src/components/layout/header.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { HeaderPresentation } from './header.presentation';
+
+const meta: Meta<typeof HeaderPresentation> = {
+	title: 'Components/Layout/Header',
+	component: HeaderPresentation,
+	args: {
+		isRefreshing: false,
+	},
+	parameters: {
+		layout: 'fullscreen',
+	},
+	render: (props) => <HeaderPresentation {...props} />,
+};
+
+export default meta;
+type Story = StoryObj<typeof HeaderPresentation>;
+
+export const Primary: Story = {};

--- a/ui/src/components/layout/layout.presentation.tsx
+++ b/ui/src/components/layout/layout.presentation.tsx
@@ -3,10 +3,10 @@ import { elementTemplate } from '../templating';
 import { Tooltips } from '../tooltips';
 import styles from './layout.module.css';
 import { LoadingSection } from './LoadingSection';
-import type { HeaderProps } from './header.presentation';
+import type { HeaderPresentationalProps } from './header.presentation';
 
 export type LayoutProps = {
-	header: React.ComponentType<HeaderProps>;
+	header: React.ComponentType<HeaderPresentationalProps>;
 	children?: React.ReactNode;
 };
 

--- a/ui/src/components/layout/layout.stories.tsx
+++ b/ui/src/components/layout/layout.stories.tsx
@@ -1,6 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { HeaderPresentation } from './header.presentation';
 import { LayoutPresentation } from './layout.presentation';
+import type { HeaderPresentationalProps } from './header.presentation';
+
+function StorybookHeaderPresentation(props: HeaderPresentationalProps) {
+	return (
+		<HeaderPresentation {...props} isRefreshing={false} onRefresh={() => {}} />
+	);
+}
 
 const meta: Meta<typeof LayoutPresentation> = {
 	title: 'Components/Layout',
@@ -9,7 +16,7 @@ const meta: Meta<typeof LayoutPresentation> = {
 		layout: 'fullscreen',
 	},
 	render: (props) => (
-		<LayoutPresentation {...props} header={HeaderPresentation} />
+		<LayoutPresentation {...props} header={StorybookHeaderPresentation} />
 	),
 };
 

--- a/ui/src/i18n/app/en.json
+++ b/ui/src/i18n/app/en.json
@@ -1,3 +1,4 @@
 {
-	"title": "ScaledGitApp"
+	"title": "ScaledGitApp",
+	"refresh": "Refresh"
 }


### PR DESCRIPTION
Adds a "refresh" button to the UI header to ensure fresh data from the git server.
- Adds `--prune` to `git fetch` commands to ensure old branches are removed
- Allows the UI to call the `git fetch` API equivalent
- When the UI completes the call to `git fetch`, invalidates all queries and keeps the fetch button disabled in the meantime.