### PR TITLE
Import order fixes

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -97,7 +97,6 @@ module.exports = {
 							'parent',
 							'sibling',
 							'index',
-							'type',
 							'object',
 							'unknown',
 						],
@@ -108,8 +107,13 @@ module.exports = {
 								position: 'before',
 							},
 							{
-								pattern: '@*/**',
+								pattern: '@!(/)*/**',
 								group: 'external',
+								position: 'before',
+							},
+							{
+								pattern: '@/**',
+								group: 'internal',
 								position: 'before',
 							},
 						],

--- a/ui/src/components/branch-display/BranchName.tsx
+++ b/ui/src/components/branch-display/BranchName.tsx
@@ -1,8 +1,8 @@
 import { InlineText } from '../common';
 import { FullSizeSvg } from '../svg/full-size-svg';
 import { BranchSvgCircle } from './BranchSvgCircle';
-import { useActiveBranchOnHover } from './useActiveBranchOnHover';
 import type { BranchInfo } from './types';
+import { useActiveBranchOnHover } from './useActiveBranchOnHover';
 
 export function BranchName({ data }: { data: BranchInfo }) {
 	const onHover = useActiveBranchOnHover(data);

--- a/ui/src/components/branch-display/types.ts
+++ b/ui/src/components/branch-display/types.ts
@@ -2,7 +2,7 @@ import type {
 	Branch,
 	BranchConfiguration,
 	BranchDetails,
-} from '../../generated/api/models';
+} from '@/generated/api/models';
 
 export type BranchInfo = Branch &
 	(Partial<BranchConfiguration> | Partial<BranchDetails>);

--- a/ui/src/components/branch-graph/BranchLink.tsx
+++ b/ui/src/components/branch-graph/BranchLink.tsx
@@ -1,12 +1,9 @@
+import type { Branch, DetailedUpstreamBranch } from '@/generated/api/models';
 import { twMerge } from 'tailwind-merge';
 import { isDetailed } from '../branch-display';
 import { JotaiG, JotaiLine } from '../svg/atom-elements';
 import { useComputedLinkValues } from './useComputedLinkValues';
 import type { BranchGraphLinkDatum, WithAtom } from './branch-graph.simulation';
-import type {
-	Branch,
-	DetailedUpstreamBranch,
-} from '../../generated/api/models';
 
 function isDetailedUpstream(
 	branch: Branch | undefined,

--- a/ui/src/components/branch-graph/BranchLink.tsx
+++ b/ui/src/components/branch-graph/BranchLink.tsx
@@ -1,9 +1,9 @@
-import type { Branch, DetailedUpstreamBranch } from '@/generated/api/models';
 import { twMerge } from 'tailwind-merge';
+import type { Branch, DetailedUpstreamBranch } from '@/generated/api/models';
 import { isDetailed } from '../branch-display';
 import { JotaiG, JotaiLine } from '../svg/atom-elements';
-import { useComputedLinkValues } from './useComputedLinkValues';
 import type { BranchGraphLinkDatum, WithAtom } from './branch-graph.simulation';
+import { useComputedLinkValues } from './useComputedLinkValues';
 
 function isDetailedUpstream(
 	branch: Branch | undefined,

--- a/ui/src/components/branch-graph/BranchNode.tsx
+++ b/ui/src/components/branch-graph/BranchNode.tsx
@@ -1,5 +1,5 @@
-import { setupDragHandler } from '@/utils/dragging';
 import { useComputedAtom } from '@principlestudios/jotai-react-signals';
+import { setupDragHandler } from '@/utils/dragging';
 import { BranchSvgCircle } from '../branch-display';
 import { JotaiG } from '../svg/atom-elements';
 import type { BranchGraphNodeDatum, WithAtom } from './branch-graph.simulation';

--- a/ui/src/components/branch-graph/BranchNode.tsx
+++ b/ui/src/components/branch-graph/BranchNode.tsx
@@ -1,5 +1,5 @@
+import { setupDragHandler } from '@/utils/dragging';
 import { useComputedAtom } from '@principlestudios/jotai-react-signals';
-import { setupDragHandler } from '../../utils/dragging';
 import { BranchSvgCircle } from '../branch-display';
 import { JotaiG } from '../svg/atom-elements';
 import type { BranchGraphNodeDatum, WithAtom } from './branch-graph.simulation';

--- a/ui/src/components/branch-graph/CenterG.tsx
+++ b/ui/src/components/branch-graph/CenterG.tsx
@@ -1,7 +1,7 @@
-import type { ElementDimensions } from '@/utils/atoms/useResizeDetector';
 import { useComputedAtom } from '@principlestudios/jotai-react-signals';
-import { JotaiG } from '../svg/atom-elements';
 import type { Atom } from 'jotai';
+import type { ElementDimensions } from '@/utils/atoms/useResizeDetector';
+import { JotaiG } from '../svg/atom-elements';
 
 export function CenterG({
 	size,

--- a/ui/src/components/branch-graph/CenterG.tsx
+++ b/ui/src/components/branch-graph/CenterG.tsx
@@ -1,6 +1,6 @@
+import type { ElementDimensions } from '@/utils/atoms/useResizeDetector';
 import { useComputedAtom } from '@principlestudios/jotai-react-signals';
 import { JotaiG } from '../svg/atom-elements';
-import type { ElementDimensions } from '../../utils/atoms/useResizeDetector';
 import type { Atom } from 'jotai';
 
 export function CenterG({

--- a/ui/src/components/branch-graph/branch-graph.presentation.tsx
+++ b/ui/src/components/branch-graph/branch-graph.presentation.tsx
@@ -1,9 +1,9 @@
-import { useResizeDetector } from '../../utils/atoms/useResizeDetector';
+import type { Branch, BranchConfiguration } from '@/generated/api/models';
+import { useResizeDetector } from '@/utils/atoms/useResizeDetector';
 import { FullSizeSvg } from '../svg/full-size-svg';
 import { useBranchSimulation } from './branch-graph.simulation';
 import { BranchLink } from './BranchLink';
 import { BranchNode } from './BranchNode';
-import type { Branch, BranchConfiguration } from '../../generated/api/models';
 
 export type BranchGraphPresentationProps = {
 	upstreamData: BranchConfiguration[];

--- a/ui/src/components/branch-graph/branch-graph.simulation.tsx
+++ b/ui/src/components/branch-graph/branch-graph.simulation.tsx
@@ -1,4 +1,9 @@
 import { useRef } from 'react';
+import type { Branch, BranchConfiguration } from '@/generated/api/models';
+import { atomWithImperativeProxy } from '@/utils/atoms/jotai-imperative-atom';
+import type { JotaiStore } from '@/utils/atoms/JotaiStore';
+import type { ElementDimensions } from '@/utils/atoms/useResizeDetector';
+import { isNumber } from '@/utils/isNumber';
 import {
 	forceCollide,
 	forceLink,
@@ -6,14 +11,9 @@ import {
 	forceSimulation,
 } from 'd3-force';
 import { useStore, type Atom } from 'jotai';
-import { atomWithImperativeProxy } from '../../utils/atoms/jotai-imperative-atom';
-import { isNumber } from '../../utils/isNumber';
 import { forceWithinBoundaries } from './forceWithinBoundaries';
 import { neutralizeVelocity } from './neutralizeVelocity';
 import { useAnimationFrame } from './useAnimationFrame';
-import type { Branch, BranchConfiguration } from '../../generated/api/models';
-import type { JotaiStore } from '../../utils/atoms/JotaiStore';
-import type { ElementDimensions } from '../../utils/atoms/useResizeDetector';
 import type { BranchInfo } from '../branch-display';
 import type {
 	ForceLink,

--- a/ui/src/components/branch-graph/branch-graph.simulation.tsx
+++ b/ui/src/components/branch-graph/branch-graph.simulation.tsx
@@ -1,26 +1,26 @@
 import { useRef } from 'react';
-import type { Branch, BranchConfiguration } from '@/generated/api/models';
-import { atomWithImperativeProxy } from '@/utils/atoms/jotai-imperative-atom';
-import type { JotaiStore } from '@/utils/atoms/JotaiStore';
-import type { ElementDimensions } from '@/utils/atoms/useResizeDetector';
-import { isNumber } from '@/utils/isNumber';
 import {
 	forceCollide,
 	forceLink,
 	forceManyBody,
 	forceSimulation,
 } from 'd3-force';
-import { useStore, type Atom } from 'jotai';
-import { forceWithinBoundaries } from './forceWithinBoundaries';
-import { neutralizeVelocity } from './neutralizeVelocity';
-import { useAnimationFrame } from './useAnimationFrame';
-import type { BranchInfo } from '../branch-display';
 import type {
 	ForceLink,
 	Simulation,
 	SimulationLinkDatum,
 	SimulationNodeDatum,
 } from 'd3-force';
+import { useStore, type Atom } from 'jotai';
+import type { Branch, BranchConfiguration } from '@/generated/api/models';
+import { atomWithImperativeProxy } from '@/utils/atoms/jotai-imperative-atom';
+import type { JotaiStore } from '@/utils/atoms/JotaiStore';
+import type { ElementDimensions } from '@/utils/atoms/useResizeDetector';
+import { isNumber } from '@/utils/isNumber';
+import type { BranchInfo } from '../branch-display';
+import { forceWithinBoundaries } from './forceWithinBoundaries';
+import { neutralizeVelocity } from './neutralizeVelocity';
+import { useAnimationFrame } from './useAnimationFrame';
 
 const maxUnknownBranchPerNodeCount = 5;
 const maxUnknownBranchCount = 100;

--- a/ui/src/components/branch-graph/forceWithinBoundaries.tsx
+++ b/ui/src/components/branch-graph/forceWithinBoundaries.tsx
@@ -1,5 +1,5 @@
-import { isNumber } from '../../utils/isNumber';
-import type { ElementDimensions } from '../../utils/atoms/useResizeDetector';
+import type { ElementDimensions } from '@/utils/atoms/useResizeDetector';
+import { isNumber } from '@/utils/isNumber';
 import type { SimulationNodeDatum } from 'd3-force';
 
 export function forceWithinBoundaries<TNode extends SimulationNodeDatum>(

--- a/ui/src/components/branch-graph/forceWithinBoundaries.tsx
+++ b/ui/src/components/branch-graph/forceWithinBoundaries.tsx
@@ -1,6 +1,6 @@
+import type { SimulationNodeDatum } from 'd3-force';
 import type { ElementDimensions } from '@/utils/atoms/useResizeDetector';
 import { isNumber } from '@/utils/isNumber';
-import type { SimulationNodeDatum } from 'd3-force';
 
 export function forceWithinBoundaries<TNode extends SimulationNodeDatum>(
 	getSize: () => ElementDimensions,

--- a/ui/src/components/branch-graph/index.tsx
+++ b/ui/src/components/branch-graph/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
+import { queries } from '@/utils/api/queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { queries } from '../../utils/api/queries';
 import { BranchGraphPresentation } from './branch-graph.presentation';
 
 export function useBranchGraph() {

--- a/ui/src/components/branch-graph/index.tsx
+++ b/ui/src/components/branch-graph/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
-import { queries } from '@/utils/api/queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { queries } from '@/utils/api/queries';
 import { BranchGraphPresentation } from './branch-graph.presentation';
 
 export function useBranchGraph() {

--- a/ui/src/components/form/field/index.tsx
+++ b/ui/src/components/form/field/index.tsx
@@ -1,8 +1,8 @@
+import type { Atom } from 'jotai';
 import { JotaiDiv } from '../../jotai/div';
 import { JotaiLabel } from '../../jotai/label';
 import { JotaiSpan } from '../../jotai/span';
 import { useTwMerge } from '../../jotai/useTwMerge';
-import type { Atom } from 'jotai';
 
 export type FieldProps = React.ComponentProps<typeof JotaiLabel> & {
 	noLabel?: boolean;

--- a/ui/src/components/form/select-field/index.tsx
+++ b/ui/src/components/form/select-field/index.tsx
@@ -1,11 +1,11 @@
-import { translateField } from '@/utils/translations';
+import type { TFunction } from 'i18next';
 import { elementTemplate } from '../../templating';
 import { ErrorsList } from '../errors-list';
 import { Field } from '../field';
+import type { StandardField } from '../FieldProps';
+import { translateField } from '../utils/translations';
 import { SelectInput } from './select-input';
 import type { SelectInputProps } from './select-input';
-import type { StandardField } from '../FieldProps';
-import type { TFunction } from 'i18next';
 
 export const NotSelected = elementTemplate('NotSelected', 'span', (T) => (
 	<T className="text-slate-500" />

--- a/ui/src/components/form/select-field/index.tsx
+++ b/ui/src/components/form/select-field/index.tsx
@@ -1,7 +1,7 @@
+import { translateField } from '@/utils/translations';
 import { elementTemplate } from '../../templating';
 import { ErrorsList } from '../errors-list';
 import { Field } from '../field';
-import { translateField } from '../utils/translations';
 import { SelectInput } from './select-input';
 import type { SelectInputProps } from './select-input';
 import type { StandardField } from '../FieldProps';

--- a/ui/src/components/form/select-field/select-input.tsx
+++ b/ui/src/components/form/select-field/select-input.tsx
@@ -3,9 +3,9 @@ import { Listbox, Transition } from '@headlessui/react';
 import { useAsAtom } from '@principlestudios/jotai-react-signals';
 import type { ControlledHtmlProps } from '@principlestudios/react-jotai-forms';
 import { useAtomValue } from 'jotai';
+import type { Atom } from 'jotai';
 import { HiCheck, HiChevronUpDown } from 'react-icons/hi2';
 import { twMerge } from 'tailwind-merge';
-import type { Atom } from 'jotai';
 
 export type SelectInputProps<T> = {
 	className?: string | Atom<string>;

--- a/ui/src/components/form/text-field/index.tsx
+++ b/ui/src/components/form/text-field/index.tsx
@@ -1,12 +1,12 @@
-import { translateField } from '@/utils/translations';
 import { useComputedAtom } from '@principlestudios/jotai-react-signals';
+import type { JotaiLabel } from '../../jotai/label';
 import { useTwMerge } from '../../jotai/useTwMerge';
 import { elementTemplate } from '../../templating';
 import { ErrorsList } from '../errors-list';
 import { Field } from '../field';
-import { TextInput } from './text-input';
-import type { JotaiLabel } from '../../jotai/label';
 import type { FieldProps } from '../FieldProps';
+import { translateField } from '../utils/translations';
+import { TextInput } from './text-input';
 
 export type TextFieldPersistentProps = {
 	description?: boolean;

--- a/ui/src/components/form/text-field/index.tsx
+++ b/ui/src/components/form/text-field/index.tsx
@@ -1,9 +1,9 @@
+import { translateField } from '@/utils/translations';
 import { useComputedAtom } from '@principlestudios/jotai-react-signals';
 import { useTwMerge } from '../../jotai/useTwMerge';
 import { elementTemplate } from '../../templating';
 import { ErrorsList } from '../errors-list';
 import { Field } from '../field';
-import { translateField } from '../utils/translations';
 import { TextInput } from './text-input';
 import type { JotaiLabel } from '../../jotai/label';
 import type { FieldProps } from '../FieldProps';

--- a/ui/src/components/jotai/useTwMerge.ts
+++ b/ui/src/components/jotai/useTwMerge.ts
@@ -1,7 +1,7 @@
 import { useComputedAtom } from '@principlestudios/jotai-react-signals';
 import { currentValue } from '@principlestudios/jotai-utilities/currentValue';
-import { twMerge } from 'tailwind-merge';
 import type { Atom } from 'jotai';
+import { twMerge } from 'tailwind-merge';
 import type { ClassNameValue } from 'tailwind-merge';
 
 type JotaiTwMergeParam = ClassNameValue | Atom<ClassNameValue>;

--- a/ui/src/components/layout/header.container.tsx
+++ b/ui/src/components/layout/header.container.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
+import { queries } from '@/utils/api/queries';
 import { useMutation } from '@tanstack/react-query';
-import { queries } from '../../utils/api/queries';
 import { HeaderPresentation } from './header.presentation';
 import type { HeaderPresentationalProps } from './header.presentation';
 

--- a/ui/src/components/layout/header.container.tsx
+++ b/ui/src/components/layout/header.container.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
-import { queries } from '@/utils/api/queries';
 import { useMutation } from '@tanstack/react-query';
+import { queries } from '@/utils/api/queries';
 import { HeaderPresentation } from './header.presentation';
 import type { HeaderPresentationalProps } from './header.presentation';
 

--- a/ui/src/components/layout/layout.presentation.tsx
+++ b/ui/src/components/layout/layout.presentation.tsx
@@ -1,9 +1,9 @@
 import { twMerge } from 'tailwind-merge';
 import { elementTemplate } from '../templating';
 import { Tooltips } from '../tooltips';
+import type { HeaderPresentationalProps } from './header.presentation';
 import styles from './layout.module.css';
 import { LoadingSection } from './LoadingSection';
-import type { HeaderPresentationalProps } from './header.presentation';
 
 export type LayoutProps = {
 	header: React.ComponentType<HeaderPresentationalProps>;

--- a/ui/src/components/layout/layout.stories.tsx
+++ b/ui/src/components/layout/layout.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { HeaderPresentation } from './header.presentation';
-import { LayoutPresentation } from './layout.presentation';
 import type { HeaderPresentationalProps } from './header.presentation';
+import { LayoutPresentation } from './layout.presentation';
 
 function StorybookHeaderPresentation(props: HeaderPresentationalProps) {
 	return (

--- a/ui/src/components/tooltips/Tooltips.tsx
+++ b/ui/src/components/tooltips/Tooltips.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo } from 'react';
-import { subscribeToDimensionChanges } from '@/utils/atoms/subscribeToDimensionChanges';
-import type { ElementDimensions } from '@/utils/atoms/useResizeDetector';
 import {
 	useComputedAtom,
 	withSignal,
 } from '@principlestudios/jotai-react-signals';
 import { atom, useStore, useAtomValue } from 'jotai';
+import { subscribeToDimensionChanges } from '@/utils/atoms/subscribeToDimensionChanges';
+import type { ElementDimensions } from '@/utils/atoms/useResizeDetector';
 import { tooltipState } from './state';
 import { TooltipContainer } from './TooltipContainer';
 

--- a/ui/src/components/tooltips/Tooltips.tsx
+++ b/ui/src/components/tooltips/Tooltips.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useMemo } from 'react';
+import { subscribeToDimensionChanges } from '@/utils/atoms/subscribeToDimensionChanges';
+import type { ElementDimensions } from '@/utils/atoms/useResizeDetector';
 import {
 	useComputedAtom,
 	withSignal,
 } from '@principlestudios/jotai-react-signals';
 import { atom, useStore, useAtomValue } from 'jotai';
-import { subscribeToDimensionChanges } from '../../utils/atoms/subscribeToDimensionChanges';
 import { tooltipState } from './state';
 import { TooltipContainer } from './TooltipContainer';
-import type { ElementDimensions } from '../../utils/atoms/useResizeDetector';
 
 export function Tooltips() {
 	const store = useStore();

--- a/ui/src/pages/about/index.tsx
+++ b/ui/src/pages/about/index.tsx
@@ -1,4 +1,4 @@
-import { Section } from '../../components/common';
+import { Section } from '@/components/common';
 import { useGitVersion } from './useGitVersion';
 
 export function AboutComponent() {

--- a/ui/src/pages/about/useGitVersion.tsx
+++ b/ui/src/pages/about/useGitVersion.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
+import { queries } from '@/utils/api/queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { queries } from '../../utils/api/queries';
 
 export function useGitVersion() {
 	const result = useSuspenseQuery(queries.getInfo);

--- a/ui/src/pages/about/useGitVersion.tsx
+++ b/ui/src/pages/about/useGitVersion.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
-import { queries } from '@/utils/api/queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { queries } from '@/utils/api/queries';
 
 export function useGitVersion() {
 	const result = useSuspenseQuery(queries.getInfo);

--- a/ui/src/pages/branch-details/DetailsPanel.tsx
+++ b/ui/src/pages/branch-details/DetailsPanel.tsx
@@ -1,4 +1,7 @@
 import { useTranslation } from 'react-i18next';
+import { useForm } from '@principlestudios/react-jotai-forms';
+import { useAtomValue } from 'jotai';
+import { z } from 'zod';
 import { BranchName } from '@/components/branch-display/BranchName';
 import { Section } from '@/components/common';
 import { Details } from '@/components/details';
@@ -9,9 +12,6 @@ import type {
 	BranchDetails,
 	DetailedUpstreamBranch,
 } from '@/generated/api/models';
-import { useForm } from '@principlestudios/react-jotai-forms';
-import { useAtomValue } from 'jotai';
-import { z } from 'zod';
 import { findBranch, namesOf } from './utils';
 
 const detailsSchema = z.object({

--- a/ui/src/pages/branch-details/DetailsPanel.tsx
+++ b/ui/src/pages/branch-details/DetailsPanel.tsx
@@ -1,18 +1,18 @@
 import { useTranslation } from 'react-i18next';
-import { useForm } from '@principlestudios/react-jotai-forms';
-import { useAtomValue } from 'jotai';
-import { z } from 'zod';
-import { BranchName } from '../../components/branch-display/BranchName';
-import { Section } from '../../components/common';
-import { Details } from '../../components/details';
-import { SelectField } from '../../components/form/select-field';
-import { translateField } from '../../components/form/utils/translations';
-import { Prose } from '../../components/text';
-import { findBranch, namesOf } from './utils';
+import { BranchName } from '@/components/branch-display/BranchName';
+import { Section } from '@/components/common';
+import { Details } from '@/components/details';
+import { SelectField } from '@/components/form/select-field';
+import { translateField } from '@/components/form/utils/translations';
+import { Prose } from '@/components/text';
 import type {
 	BranchDetails,
 	DetailedUpstreamBranch,
-} from '../../generated/api/models';
+} from '@/generated/api/models';
+import { useForm } from '@principlestudios/react-jotai-forms';
+import { useAtomValue } from 'jotai';
+import { z } from 'zod';
+import { findBranch, namesOf } from './utils';
 
 const detailsSchema = z.object({
 	mainBranch: z.string(),

--- a/ui/src/pages/branch-details/RecommendationsPanel.tsx
+++ b/ui/src/pages/branch-details/RecommendationsPanel.tsx
@@ -1,13 +1,10 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Section } from '../../components/common';
-import { Code, Heading, HintText } from '../../components/text';
-import { useRecommendationsEngine } from '../../recommendations';
-import type { BranchDetails } from '../../generated/api/models';
-import type {
-	RecommendationsEngine,
-	Recommendation,
-} from '../../recommendations';
+import { Section } from '@/components/common';
+import { Code, Heading, HintText } from '@/components/text';
+import type { BranchDetails } from '@/generated/api/models';
+import { useRecommendationsEngine } from '@/recommendations';
+import type { RecommendationsEngine, Recommendation } from '@/recommendations';
 
 export type RecommendationsPanelComponent = React.FC<{
 	branches: BranchDetails[];

--- a/ui/src/pages/branch-details/index.tsx
+++ b/ui/src/pages/branch-details/index.tsx
@@ -1,19 +1,19 @@
 import { useTranslation } from 'react-i18next';
 import type { NavigateFunction } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
+import { useSuspenseQueries } from '@tanstack/react-query';
 import { BranchGraphPresentation } from '@/components/branch-graph/branch-graph.presentation';
 import { Container } from '@/components/common';
 import { LoadingSection } from '@/components/layout/LoadingSection';
 import { Tab } from '@/components/tabs';
 import type { BranchDetails } from '@/generated/api/models';
 import { queries } from '@/utils/api/queries';
-import { useSuspenseQueries } from '@tanstack/react-query';
 import styles from './branch-details.module.css';
 import { DetailsPanel } from './DetailsPanel';
 import { useRecommendationsPanel } from './RecommendationsPanel';
+import type { RecommendationsPanelComponent } from './RecommendationsPanel';
 import { useBranchDetails } from './useBranchDetails';
 import { namesOf } from './utils';
-import type { RecommendationsPanelComponent } from './RecommendationsPanel';
 
 export function BranchDetailsComponent({ name }: { name: string[] }) {
 	const navigate = useNavigate();

--- a/ui/src/pages/branch-details/index.tsx
+++ b/ui/src/pages/branch-details/index.tsx
@@ -1,19 +1,19 @@
 import { useTranslation } from 'react-i18next';
 import type { NavigateFunction } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
+import { BranchGraphPresentation } from '@/components/branch-graph/branch-graph.presentation';
+import { Container } from '@/components/common';
+import { LoadingSection } from '@/components/layout/LoadingSection';
+import { Tab } from '@/components/tabs';
+import type { BranchDetails } from '@/generated/api/models';
+import { queries } from '@/utils/api/queries';
 import { useSuspenseQueries } from '@tanstack/react-query';
-import { BranchGraphPresentation } from '../../components/branch-graph/branch-graph.presentation';
-import { Container } from '../../components/common';
-import { LoadingSection } from '../../components/layout/LoadingSection';
-import { Tab } from '../../components/tabs';
-import { queries } from '../../utils/api/queries';
 import styles from './branch-details.module.css';
 import { DetailsPanel } from './DetailsPanel';
 import { useRecommendationsPanel } from './RecommendationsPanel';
 import { useBranchDetails } from './useBranchDetails';
 import { namesOf } from './utils';
 import type { RecommendationsPanelComponent } from './RecommendationsPanel';
-import type { BranchDetails } from '../../generated/api/models';
 
 export function BranchDetailsComponent({ name }: { name: string[] }) {
 	const navigate = useNavigate();

--- a/ui/src/pages/branch-details/useBranchDetails.ts
+++ b/ui/src/pages/branch-details/useBranchDetails.ts
@@ -1,10 +1,10 @@
-import type { BranchDetails } from '@/generated/api/models';
-import { queries } from '@/utils/api/queries';
 import {
 	useQueryClient,
 	useSuspenseQueries,
 	useQueries,
 } from '@tanstack/react-query';
+import type { BranchDetails } from '@/generated/api/models';
+import { queries } from '@/utils/api/queries';
 
 export function useBranchDetails(names: string[]) {
 	const queryClient = useQueryClient();

--- a/ui/src/pages/branch-details/useBranchDetails.ts
+++ b/ui/src/pages/branch-details/useBranchDetails.ts
@@ -1,10 +1,10 @@
+import type { BranchDetails } from '@/generated/api/models';
+import { queries } from '@/utils/api/queries';
 import {
 	useQueryClient,
 	useSuspenseQueries,
 	useQueries,
 } from '@tanstack/react-query';
-import { queries } from '../../utils/api/queries';
-import type { BranchDetails } from '../../generated/api/models';
 
 export function useBranchDetails(names: string[]) {
 	const queryClient = useQueryClient();

--- a/ui/src/pages/branch-details/utils.ts
+++ b/ui/src/pages/branch-details/utils.ts
@@ -1,4 +1,4 @@
-import type { Branch } from '../../generated/api/models';
+import type { Branch } from '@/generated/api/models';
 
 export function namesOf(branches: Branch[]) {
 	return branches.map((b) => b.name);

--- a/ui/src/pages/login/index.tsx
+++ b/ui/src/pages/login/index.tsx
@@ -1,8 +1,8 @@
 import { useTranslation } from 'react-i18next';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Container, ExternalLink, Section } from '@/components/common';
 import { Prose } from '@/components/text';
 import { queries } from '@/utils/api/queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
 
 export function LoginComponent({ returnUrl }: { returnUrl: string[] }) {
 	const schemes = useSuspenseQuery(queries.getLoginSchemes);

--- a/ui/src/pages/login/index.tsx
+++ b/ui/src/pages/login/index.tsx
@@ -1,8 +1,8 @@
 import { useTranslation } from 'react-i18next';
+import { Container, ExternalLink, Section } from '@/components/common';
+import { Prose } from '@/components/text';
+import { queries } from '@/utils/api/queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Container, ExternalLink, Section } from '../../components/common';
-import { Prose } from '../../components/text';
-import { queries } from '../../utils/api/queries';
 
 export function LoginComponent({ returnUrl }: { returnUrl: string[] }) {
 	const schemes = useSuspenseQuery(queries.getLoginSchemes);

--- a/ui/src/pages/overview/branch-listing.tsx
+++ b/ui/src/pages/overview/branch-listing.tsx
@@ -1,13 +1,13 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { BulletList, Link, Section } from '@/components/common';
+import type { StandardField } from '@/components/form/FieldProps';
+import { TextField } from '@/components/form/text-field';
+import { queries } from '@/utils/api/queries';
 import { useForm } from '@principlestudios/react-jotai-forms';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useAtomValue } from 'jotai';
 import { z } from 'zod';
-import { BulletList, Link, Section } from '../../components/common';
-import { TextField } from '../../components/form/text-field';
-import { queries } from '../../utils/api/queries';
-import type { StandardField } from '../../components/form/FieldProps';
 import type { TFunction } from 'i18next';
 
 const branchListingSearchSchema = z.object({

--- a/ui/src/pages/overview/branch-listing.tsx
+++ b/ui/src/pages/overview/branch-listing.tsx
@@ -1,14 +1,14 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useForm } from '@principlestudios/react-jotai-forms';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import type { TFunction } from 'i18next';
+import { useAtomValue } from 'jotai';
+import { z } from 'zod';
 import { BulletList, Link, Section } from '@/components/common';
 import type { StandardField } from '@/components/form/FieldProps';
 import { TextField } from '@/components/form/text-field';
 import { queries } from '@/utils/api/queries';
-import { useForm } from '@principlestudios/react-jotai-forms';
-import { useSuspenseQuery } from '@tanstack/react-query';
-import { useAtomValue } from 'jotai';
-import { z } from 'zod';
-import type { TFunction } from 'i18next';
 
 const branchListingSearchSchema = z.object({
 	branchName: z.string(),

--- a/ui/src/pages/overview/index.tsx
+++ b/ui/src/pages/overview/index.tsx
@@ -1,4 +1,4 @@
-import { Container } from '../../components/common';
+import { Container } from '@/components/common';
 import { useBranchListing } from './branch-listing';
 
 export function OverviewComponent() {

--- a/ui/src/recommendations/index.tsx
+++ b/ui/src/recommendations/index.tsx
@@ -1,4 +1,4 @@
-import { useSuspensePromise } from '../utils/useSuspensePromise';
+import { useSuspensePromise } from '@/utils/useSuspensePromise';
 import { loadAllRules } from './load-all-rules';
 import type { RecommendationsEngine } from './rule-base';
 

--- a/ui/src/recommendations/rule-base.ts
+++ b/ui/src/recommendations/rule-base.ts
@@ -1,4 +1,4 @@
-import type { BranchDetails } from '../generated/api/models';
+import type { BranchDetails } from '@/generated/api/models';
 
 export type RecommendationsEngine = {
 	getRecommendations: (branches: BranchDetails[]) => Recommendation[];

--- a/ui/src/utils/api/fetch-api.ts
+++ b/ui/src/utils/api/fetch-api.ts
@@ -1,5 +1,5 @@
+import operations from '@/generated/api/operations';
 import { toFetchApi } from '@principlestudios/openapi-codegen-typescript-fetch';
-import operations from '../../generated/api/operations';
 
 export const api = toFetchApi(operations, async (url, req) => {
 	const result = await fetch(url, req);

--- a/ui/src/utils/api/fetch-api.ts
+++ b/ui/src/utils/api/fetch-api.ts
@@ -1,5 +1,5 @@
-import operations from '@/generated/api/operations';
 import { toFetchApi } from '@principlestudios/openapi-codegen-typescript-fetch';
+import operations from '@/generated/api/operations';
 
 export const api = toFetchApi(operations, async (url, req) => {
 	const result = await fetch(url, req);

--- a/ui/src/utils/api/queries/index.ts
+++ b/ui/src/utils/api/queries/index.ts
@@ -1,9 +1,9 @@
+import type operations from '@/generated/api/operations';
 import { getLoginSchemes } from './auth/get-login-schemes';
 import { getInfo } from './environment';
 import { getBranchDetails } from './git/branch-details';
 import { requestGitFetch } from './git/fetch';
 import { getUpstreamData } from './git/upstream-data';
-import type operations from '../../../generated/api/operations';
 
 export const queries = {
 	getInfo,

--- a/ui/src/utils/atoms/subscribeToDimensionChanges.ts
+++ b/ui/src/utils/atoms/subscribeToDimensionChanges.ts
@@ -1,6 +1,6 @@
+import type { PrimitiveAtom } from 'jotai';
 import type { JotaiStore } from './JotaiStore';
 import type { ElementDimensions } from './useResizeDetector';
-import type { PrimitiveAtom } from 'jotai';
 
 export function subscribeToDimensionChanges<
 	T extends HTMLElement | SVGElement = HTMLElement,

--- a/ui/src/utils/atoms/useResizeDetector.ts
+++ b/ui/src/utils/atoms/useResizeDetector.ts
@@ -1,7 +1,7 @@
 import { useLayoutEffect, useRef, useMemo } from 'react';
 import { atom, useStore } from 'jotai';
-import { subscribeToDimensionChanges } from './subscribeToDimensionChanges';
 import type { PrimitiveAtom } from 'jotai';
+import { subscribeToDimensionChanges } from './subscribeToDimensionChanges';
 
 export interface ElementDimensions {
 	left?: number;

--- a/ui/src/utils/i18n/setup.ts
+++ b/ui/src/utils/i18n/setup.ts
@@ -1,11 +1,11 @@
 import { initReactI18next } from 'react-i18next';
-import { constructUrl as toLocalizationUrl } from '@/generated/api/operations/getTranslationData';
 import i18nextBase from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import HttpApi, { type HttpBackendOptions } from 'i18next-http-backend';
 import MultiloadAdapter, {
 	type MultiloadBackendOptions,
 } from 'i18next-multiload-backend-adapter';
+import { constructUrl as toLocalizationUrl } from '@/generated/api/operations/getTranslationData';
 
 const reportedKeys = new Set<string>();
 

--- a/ui/src/utils/i18n/setup.ts
+++ b/ui/src/utils/i18n/setup.ts
@@ -1,11 +1,11 @@
 import { initReactI18next } from 'react-i18next';
+import { constructUrl as toLocalizationUrl } from '@/generated/api/operations/getTranslationData';
 import i18nextBase from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import HttpApi, { type HttpBackendOptions } from 'i18next-http-backend';
 import MultiloadAdapter, {
 	type MultiloadBackendOptions,
 } from 'i18next-multiload-backend-adapter';
-import { constructUrl as toLocalizationUrl } from '../../generated/api/operations/getTranslationData';
 
 const reportedKeys = new Set<string>();
 

--- a/ui/src/utils/realtime/implementation.ts
+++ b/ui/src/utils/realtime/implementation.ts
@@ -1,7 +1,7 @@
-import { neverEver } from '@/utils/never-ever';
-import { createRealtimeApiConnection } from '@/utils/realtime/realtime.signalr';
 import type { HubConnection } from '@microsoft/signalr';
 import { HubConnectionState } from '@microsoft/signalr';
+import { neverEver } from '@/utils/never-ever';
+import { createRealtimeApiConnection } from '@/utils/realtime/realtime.signalr';
 import type {
 	HubStatusMesage,
 	MessageFromServer,

--- a/ui/src/utils/realtime/realtime-api.ts
+++ b/ui/src/utils/realtime/realtime-api.ts
@@ -1,14 +1,14 @@
 import { createContext, useContext } from 'react';
+import { HubConnectionState } from '@microsoft/signalr';
+import type { QueryClient } from '@tanstack/react-query';
+import { atom, getDefaultStore } from 'jotai';
+import type { Atom } from 'jotai';
 import { neverEver } from '@/utils/never-ever.ts';
 import type {
 	MessageFromServer,
 	MessageFromApp,
 } from '@/utils/realtime/messages';
-import { HubConnectionState } from '@microsoft/signalr';
-import type { QueryClient } from '@tanstack/react-query';
-import { atom, getDefaultStore } from 'jotai';
 import { realtimeApiEventTarget } from './implementation';
-import type { Atom } from 'jotai';
 
 const reconnectStates = [
 	HubConnectionState.Connecting,


### PR DESCRIPTION
With the addition of the `@/` prefix for JS imports, changes to the import order rules were necessary.

- Treats `@/` as internal paths so they go just underneath `external` and `builtin` paths.
- Removes `types` from having their own section so they are listed with the similar level packages
- Updates `../utils` and `../components` paths to using the corresponding `@/` paths