### PR TITLE
Main Branch CI

### DIFF
--- a/.github/workflows/docker-build-main.yaml
+++ b/.github/workflows/docker-build-main.yaml
@@ -23,9 +23,9 @@ jobs:
 
       - name: 'Build image'
         run: |
-          docker build . -t $registryLoginServer/$imageName:$dockerImageTag --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=${{ github.run_id }}
-          docker build . --build-arg DOTNET_BUILD_FLAGS="-p:IncludeAzure=true" -t $registryLoginServer/$imageName:$dockerImageTag-azure --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=${{ github.run_id }}
-          docker build . --build-arg DOTNET_BUILD_FLAGS="-p:IncludeAWS=true" -t $registryLoginServer/$imageName:$dockerImageTag-aws --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=${{ github.run_id }}
+          docker build . -t $registryLoginServer/$imageName:$dockerImageTag --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=main.${{ github.run_id }}.${{ github.run_attempt }}
+          docker build . --build-arg DOTNET_BUILD_FLAGS="-p:IncludeAzure=true" -t $registryLoginServer/$imageName:$dockerImageTag-azure --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=main.${{ github.run_id }}.${{ github.run_attempt }}
+          docker build . --build-arg DOTNET_BUILD_FLAGS="-p:IncludeAWS=true" -t $registryLoginServer/$imageName:$dockerImageTag-aws --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=main.${{ github.run_id }}.${{ github.run_attempt }}
 
       - name: 'Log in to docker registry'
         uses: azure/docker-login@v1

--- a/.github/workflows/docker-build-main.yaml
+++ b/.github/workflows/docker-build-main.yaml
@@ -1,0 +1,39 @@
+name: Build Main
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  registryLoginServer: 'principlestudios.azurecr.io'
+  imageName: 'scaledgitapp'
+  dockerImageTag: 'latest'
+
+concurrency:
+  group: main
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 'Build image'
+        run: |
+          docker build . -t $registryLoginServer/$imageName:$dockerImageTag --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=${{ github.run_id }}
+          docker build . --build-arg DOTNET_BUILD_FLAGS="-p:IncludeAzure=true" -t $registryLoginServer/$imageName:$dockerImageTag-azure --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=${{ github.run_id }}
+          docker build . --build-arg DOTNET_BUILD_FLAGS="-p:IncludeAWS=true" -t $registryLoginServer/$imageName:$dockerImageTag-aws --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=${{ github.run_id }}
+
+      - name: 'Log in to docker registry'
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ env.registryLoginServer }}
+          username: ${{ secrets.AZ_CLIENT_ID }}
+          password: ${{ secrets.AZ_CLIENT_SECRET }}
+
+      - name: 'Push image'
+        run: |
+          docker push --all-tags $registryLoginServer/$imageName

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -5,7 +5,7 @@ on: pull_request
 env:
   registryLoginServer: 'principlestudios.azurecr.io'
   imageName: 'scaledgitapp'
-  dockerImageTag: 'ci-${{ github.run_number }}'
+  dockerImageTag: 'pr-${{ github.event.pull_request.number }}'
 
 concurrency:
   # Ensures this build only is running once per PR; if new commits are pushed
@@ -22,9 +22,9 @@ jobs:
 
       - name: 'Build image'
         run: |
-          docker build . -t $registryLoginServer/$imageName:$dockerImageTag --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=${{ github.run_id }}
-          docker build . --build-arg DOTNET_BUILD_FLAGS="-p:IncludeAzure=true" -t $registryLoginServer/$imageName:$dockerImageTag-azure --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=${{ github.run_id }}
-          docker build . --build-arg DOTNET_BUILD_FLAGS="-p:IncludeAWS=true" -t $registryLoginServer/$imageName:$dockerImageTag-aws --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=${{ github.run_id }}
+          docker build . -t $registryLoginServer/$imageName:$dockerImageTag --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=pr-${{ github.event.pull_request.number }}.${{ github.run_id }}.${{ github.run_attempt }}
+          docker build . --build-arg DOTNET_BUILD_FLAGS="-p:IncludeAzure=true" -t $registryLoginServer/$imageName:$dockerImageTag-azure --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=pr-${{ github.event.pull_request.number }}.${{ github.run_id }}.${{ github.run_attempt }}
+          docker build . --build-arg DOTNET_BUILD_FLAGS="-p:IncludeAWS=true" -t $registryLoginServer/$imageName:$dockerImageTag-aws --build-arg GITHASH=${{ github.sha }} --build-arg BUILDTAG=pr-${{ github.event.pull_request.number }}.${{ github.run_id }}.${{ github.run_attempt }}
 
       - name: 'Log in to docker registry'
         uses: azure/docker-login@v1


### PR DESCRIPTION
The `/api/env` should provide enough information to determine what version was built, unfortunately, the current reported version is something like:

```
{"gitHash":"2cef631c84451dcb6df4817657ef5db2058ad09c","tag":"8528490998"}
```

This hash generally does not exist in the repository (it was the merge of a PR to main) and the tag is both indecipherable and temporary (build logs only last 90 days.)

This PR:
- Adds a build for main that will use the actual `main` SHA
- Updates the tag so that it references the PR as well as the build ID and attempt number
