### PR TITLE
Allow disabling of the command cache

### DIFF
--- a/Server/Commands/CommandCache.cs
+++ b/Server/Commands/CommandCache.cs
@@ -50,7 +50,7 @@ public sealed class CommandCache : ICommandCache, IDisposable
 	private bool IsCacheable<T, TContext>(ICommand<Task<T>, TContext> command)
 	{
 		var result = options.DefaultEnabled;
-		if (options.TypeSettings.GetValue<bool?>(command.GetType().Name) is bool typeOverride)
+		if (options.TypeSettings?.GetValue<bool?>(command.GetType().Name) is bool typeOverride)
 			result = typeOverride;
 		return result;
 	}

--- a/Server/Commands/CommandCache.cs
+++ b/Server/Commands/CommandCache.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using System.Runtime.CompilerServices;
 
@@ -7,13 +8,15 @@ namespace PrincipleStudios.ScaledGitApp.Commands;
 public sealed class CommandCache : ICommandCache, IDisposable
 {
 	private readonly IMemoryCache memoryCache;
+	private readonly CommandCacheOptions options;
 	private IChangeToken changeToken;
 	private CancellationTokenSource cancellationSource;
 
-	public CommandCache(IMemoryCache memoryCache)
+	public CommandCache(IMemoryCache memoryCache, IOptions<CommandCacheOptions> options)
 	{
 		(cancellationSource, changeToken) = CreateChangeToken();
 		this.memoryCache = memoryCache;
+		this.options = options.Value;
 	}
 
 	private static (CancellationTokenSource, IChangeToken) CreateChangeToken()
@@ -33,6 +36,7 @@ public sealed class CommandCache : ICommandCache, IDisposable
 	public async Task<T> GetCommandResultOrInvoke<T, TContext>(ICommand<Task<T>, TContext> command, Func<Task<T>> invoke)
 	{
 		if (!IsEquatable(command)) return await invoke();
+		if (!IsCacheable(command)) return await invoke();
 
 		var result = await memoryCache.GetOrCreateAsync(command, (entry) =>
 		{
@@ -41,6 +45,14 @@ public sealed class CommandCache : ICommandCache, IDisposable
 		});
 		// Nullability seems incorrect on GetOrCreate; should use the same result as the invoke
 		return result!;
+	}
+
+	private bool IsCacheable<T, TContext>(ICommand<Task<T>, TContext> command)
+	{
+		var result = options.DefaultEnabled;
+		if (options.TypeSettings.GetValue<bool?>(command.GetType().Name) is bool typeOverride)
+			result = typeOverride;
+		return result;
 	}
 
 	private static bool IsEquatable(object target)

--- a/Server/Commands/CommandCacheOptions.cs
+++ b/Server/Commands/CommandCacheOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace PrincipleStudios.ScaledGitApp.Commands;
+
+public class CommandCacheOptions
+{
+	public bool DefaultEnabled { get; set; } = true;
+	public required IConfigurationSection TypeSettings { get; init; }
+}

--- a/Server/Commands/CommandCacheOptions.cs
+++ b/Server/Commands/CommandCacheOptions.cs
@@ -3,5 +3,5 @@
 public class CommandCacheOptions
 {
 	public bool DefaultEnabled { get; set; } = true;
-	public required IConfigurationSection TypeSettings { get; init; }
+	public IConfigurationSection? TypeSettings { get; init; }
 }

--- a/Server/Commands/ServiceRegistration.cs
+++ b/Server/Commands/ServiceRegistration.cs
@@ -2,8 +2,9 @@
 
 public static class ServiceRegistration
 {
-	internal static void RegisterCommands(this IServiceCollection services)
+	internal static void RegisterCommands(this IServiceCollection services, IConfigurationSection commandConfig)
 	{
+		services.Configure<CommandCacheOptions>(commandConfig.GetSection("Cache"));
 		services.AddSingleton<ICommandCache, CommandCache>();
 		services.AddMemoryCache(options =>
 		{

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -24,7 +24,7 @@ var services = builder.Services;
 
 services.RegisterAuth(builder.Configuration.GetSection("Auth"));
 services.RegisterBranchingStrategy(builder.Configuration.GetSection("Colors"));
-services.RegisterCommands();
+services.RegisterCommands(builder.Configuration.GetSection("Command"));
 services.RegisterEnvironment(
 	isProduction: builder.Environment.IsProduction(),
 	environmentName: builder.Environment.EnvironmentName,

--- a/docs/env.md
+++ b/docs/env.md
@@ -68,6 +68,27 @@ For example:
 AUTH__EMAILADDRESSDOMAINS__0=principlestudios.com
 ```
 
+## COMMAND__CACHE__DEFAULTENABLED
+
+Default: _true_.
+
+Specifies whether the command cache is enabled. This greatly improves response
+times but also greatly increases memory usage.
+
+```
+COMMAND__CACHE__DEFAULTENABLED=false
+```
+
+## COMMAND__CACHE__TYPESETTINGS__{typeName}
+
+Overrides caching of a specific command type, based on the name. Defaults to the
+value of `COMMAND__CACHE__DEFAULTENABLED`.
+
+For example:
+```
+COMMAND__CACHE__TYPESETTINGS__GITUPSTREAMDATA=true
+```
+
 # Common Scenarios
 
 ## Working locally


### PR DESCRIPTION
Some of our git trees are rather large and are causing OOM issues.