### PR TITLE
Improve pull upstream suggestions

### DIFF
--- a/ui/src/i18n/recommendations/en.json
+++ b/ui/src/i18n/recommendations/en.json
@@ -6,6 +6,11 @@
 		"conflict": {
 			"title": "Incoming conflicts",
 			"description": "The branch '{{branch}}' is out of date with '{{incoming}}', which has conflicts."
+		},
+		"conflict-upstream": {
+			"title": "Upstream conflicts",
+			"description": "The branch '{{branch}}' further upstream has conflicts. Resolve those before continuing.",
+			"seeAlso": "Branch {{branch}}"
 		}
 	},
 	"remove-unused-branch": {

--- a/ui/src/i18n/recommendations/en.json
+++ b/ui/src/i18n/recommendations/en.json
@@ -11,6 +11,10 @@
 			"title": "Upstream conflicts",
 			"description": "The branch '{{branch}}' further upstream has conflicts. Resolve those before continuing.",
 			"seeAlso": "Branch {{branch}}"
+		},
+		"reintegrate": {
+			"title": "Reintegrate integration branch",
+			"description": "An integration branch '{{integration}}' is downstream from a branch with incoming conflicts '{{branch}}'. Merging the integration branch may resolve those conflicts."
 		}
 	},
 	"remove-unused-branch": {

--- a/ui/src/logic/getLocalData.ts
+++ b/ui/src/logic/getLocalData.ts
@@ -1,0 +1,20 @@
+import type {
+	DefaultError,
+	FetchQueryOptions,
+	QueryClient,
+	QueryKey,
+} from '@tanstack/react-query';
+
+export function getLocalData<
+	TQueryFnData,
+	TError = DefaultError,
+	TData = TQueryFnData,
+	TQueryKey extends QueryKey = QueryKey,
+>(
+	queryClient: QueryClient,
+	options: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey, never>,
+): TData | undefined {
+	return queryClient.getQueryData<TQueryFnData, TQueryKey, TData>(
+		options.queryKey,
+	);
+}

--- a/ui/src/pages/branch-details/RecommendationsPanel.tsx
+++ b/ui/src/pages/branch-details/RecommendationsPanel.tsx
@@ -63,9 +63,22 @@ function RecommendationPresentation({
 		<Section.SingleColumn>
 			<Heading.Section>{t('title', opts)}</Heading.Section>
 			<HintText>{t('description', opts)}</HintText>
-			<Code>
-				{recommendation.commands.map((command) => `${command}\n`).join('')}
-			</Code>
+			{recommendation.commands ? (
+				<Code>
+					{recommendation.commands.map((command) => `${command}\n`).join('')}
+				</Code>
+			) : null}
+			{recommendation.seeAlso ? (
+				<ul>
+					{recommendation.seeAlso.map((s) => (
+						<li key={s.key}>
+							<a className="text-blue-800 underline" href={s.url}>
+								{t(s.translationKey, { replace: s.translationParameters })}
+							</a>
+						</li>
+					))}
+				</ul>
+			) : null}
 		</Section.SingleColumn>
 	);
 }

--- a/ui/src/recommendations/rule-base.ts
+++ b/ui/src/recommendations/rule-base.ts
@@ -20,12 +20,29 @@ export type RecommendationContext = {
 	queryClient: QueryClient;
 };
 
-export type Recommendation = {
-	recommendationKey: string;
+export type TranslationMeta = {
 	translationKey: string;
-	commands: string[];
 	translationParameters?: Record<string, string | number>;
 };
+
+export type RecommendationSeeAlso = {
+	key: string;
+	url: string;
+} & TranslationMeta;
+
+export type Recommendation = {
+	recommendationKey: string;
+} & TranslationMeta &
+	(
+		| {
+				commands?: undefined;
+				seeAlso: RecommendationSeeAlso[];
+		  }
+		| {
+				commands: string[];
+				seeAlso?: undefined;
+		  }
+	);
 
 export type RecommendationOutput = Recommendation & {
 	/** A relatively magic number used to prioritize recommendations. Lower is higher priority. */

--- a/ui/src/recommendations/rules/pull-upstream.ts
+++ b/ui/src/recommendations/rules/pull-upstream.ts
@@ -1,42 +1,116 @@
+import type { BranchDetails } from '@/generated/api/models';
+import { getLocalData } from '@/logic/getLocalData';
+import { getRecursiveUpstream } from '@/logic/recursive-upstream';
+import { queries } from '@/utils/api/queries';
 import { perBranch } from '../per-branch-rule';
 
 const translationKey = 'pull-upstream';
 const conflictTranslationKey = 'pull-upstream.conflict';
+const upstreamConflictTranslationKey = 'pull-upstream.conflict-upstream';
 
 // Should be lower than "this is unused", but higher than many other
 // recommendations.
 const pullUpstreamPriority = 10;
 
 export default perBranch({
-	analyze([branch]) {
-		if (!branch.upstream.some((u) => u.behindCount > 0)) return [];
+	async analyze([branch], { queryClient }) {
+		const allUpstreamData = await queryClient.fetchQuery(
+			queries.getUpstreamData,
+		);
 
-		if (branch.upstream.some((u) => u.hasConflict)) {
+		// Get all upstream branches currently in the query cache and filter to
+		// those that are behind their immediate upstreams or have conflicts
+		// with their immediate upstreams.
+		const relevantBranches = [
+			branch.name,
+			...getRecursiveUpstream(branch.name, allUpstreamData),
+		]
+			.map((u) => getLocalData(queryClient, queries.getBranchDetails(u)))
+			.flatMap((u) => (u ? [u] : []))
+			.filter((b) =>
+				b.upstream.some((u) => u.behindCount > 0 || u.hasConflict),
+			);
+
+		// If nothing has incoming changes or conflicts, exit early
+		if (!relevantBranches.length) return [];
+		const conflicts = relevantBranches.filter((b) =>
+			b.upstream.some((u) => u.hasConflict),
+		);
+
+		// If there are conflicts with only the current branch, report how to resolve those.
+		if (isArrayOfCurrentBranch(conflicts)) {
+			// TODO: if there is an integration branch downstream, and its other
+			// upstreams are all merged into this branch's upstreams, then
+			// recommend reusing the integration branch. (This behavior is worth
+			// an `await`.)
+
 			return branch.upstream
 				.filter((u) => u.hasConflict)
-				.map(({ name }) => ({
-					recommendationKey: `${conflictTranslationKey}-${branch.name}-${name}`,
-					priority: pullUpstreamPriority,
-					translationKey: conflictTranslationKey,
-					commands: [`git checkout ${branch.name}`, `git merge origin/${name}`],
-					translationParameters: {
-						branch: branch.name,
-						incoming: name,
-					},
-				}));
+				.map(({ name }) => reportConflictWithMainBranch(branch.name, name));
 		}
 
-		const commands = [`git pull-upstream ${branch.name}`];
-		return [
-			{
-				recommendationKey: `${translationKey}-${branch.name}`,
-				priority: pullUpstreamPriority,
-				translationKey,
-				commands,
-				translationParameters: {
-					branch: branch.name,
-				},
-			},
-		];
+		// If there are conflicts further up the upstream list, suggest resolving those first.
+		if (conflicts.length) {
+			// resolve upstream branch conflicts first
+			return conflicts
+				.filter((b) => b !== branch)
+				.map(({ name }) => reportConflictInUpstreamBranch(branch.name, name));
+		}
+
+		// Otherwise, this is a standard pull-upstream, which may need to be recursive.
+		const recurse = !isArrayOfCurrentBranch(relevantBranches);
+		return [reportStandardPullUpstream(branch.name, recurse)];
+
+		function isArrayOfCurrentBranch(sample: BranchDetails[]) {
+			return sample.length === 1 && sample[0].name === branch.name;
+		}
 	},
 });
+
+function reportConflictWithMainBranch(target: string, incoming: string) {
+	return {
+		recommendationKey: `${conflictTranslationKey}-${target}-${incoming}`,
+		priority: pullUpstreamPriority,
+		translationKey: conflictTranslationKey,
+		commands: [`git checkout ${target}`, `git merge origin/${incoming}`],
+		translationParameters: {
+			branch: target,
+			incoming: incoming,
+		},
+	};
+}
+
+function reportConflictInUpstreamBranch(target: string, name: string) {
+	return {
+		recommendationKey: `${upstreamConflictTranslationKey}-${target}-${name}`,
+		priority: pullUpstreamPriority,
+		translationKey: upstreamConflictTranslationKey,
+		seeAlso: [
+			{
+				key: 'branch',
+				url: `#/branch?name=${encodeURIComponent(name)}`,
+				translationKey: `seeAlso`,
+				translationParameters: {
+					branch: name,
+				},
+			},
+		],
+		translationParameters: {
+			branch: name,
+		},
+	};
+}
+
+function reportStandardPullUpstream(target: string, recurse: boolean) {
+	return {
+		recommendationKey: `${translationKey}-${target}`,
+		priority: pullUpstreamPriority,
+		translationKey,
+		commands: [
+			`git pull-upstream ${target} ${recurse ? '-recurse' : ''}`.trimEnd(),
+		],
+		translationParameters: {
+			branch: target,
+		},
+	};
+}


### PR DESCRIPTION
This significantly expands the "pull-upstream" recommendations. If any conflicts are detected upstream, the app will no longer recommend a simple `pull-upstream`, instead:
- If there are conflicts further upstream, a "See Also" link is provided to go directly to that one to get recommendations.
- If an integration branch is detected downstream, and all of its branches have been merged into their upstreams, this will recommend re-integrating the integration branch.
- Finally, a direct merge is recommended if no other suggestions apply.