### PR TITLE
Remove confusing type alias

### DIFF
--- a/schemas/api.yaml
+++ b/schemas/api.yaml
@@ -92,7 +92,8 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpstreamBranches'
+                type: array
+                items: { $ref: '#/components/schemas/BranchConfiguration' }
   /api/git/branch-details:
     post:
       x-dotnet-mvc-server-controller: GitBranchDetails
@@ -118,10 +119,6 @@ paths:
               schema: { $ref: '#/components/schemas/BranchDetails' }
 components:
   schemas:
-    UpstreamBranches:
-      type: array
-      items:
-        $ref: '#/components/schemas/BranchConfiguration'
     BranchConfiguration:
       type: object
       required:

--- a/ui/src/logic/recursive-upstream.ts
+++ b/ui/src/logic/recursive-upstream.ts
@@ -1,8 +1,8 @@
-import type { UpstreamBranches } from '@/generated/api/models';
+import type { BranchConfiguration } from '@/generated/api/models';
 
 export function getRecursiveUpstream(
 	target: string,
-	upstreamData: UpstreamBranches,
+	upstreamData: BranchConfiguration[],
 ) {
 	const result = new Set<string>();
 	const stack = [target];

--- a/ui/src/recommendations/rules/pull-upstream.ts
+++ b/ui/src/recommendations/rules/pull-upstream.ts
@@ -2,7 +2,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import type {
 	Branch,
 	BranchDetails,
-	UpstreamBranches,
+	BranchConfiguration,
 } from '@/generated/api/models';
 import { getLocalData } from '@/logic/getLocalData';
 import { getRecursiveUpstream } from '@/logic/recursive-upstream';
@@ -85,7 +85,7 @@ export default perBranch({
 
 async function getReintegrationCandidates(
 	branch: BranchDetails,
-	allUpstreamData: UpstreamBranches,
+	allUpstreamData: BranchConfiguration[],
 	queryClient: QueryClient,
 ) {
 	// If there is an integration branch downstream, and its other upstreams are


### PR DESCRIPTION
This PR removes an OpenAPI type alias that looked like an object but was an array in TS, but did not get generated in C# (because there cannot be aliases for an array type).