### PR TITLE
Include merge commits to be propagated

### DIFF
--- a/Server.Tests/Git/ToolsCommands/GetCommitCountShould.cs
+++ b/Server.Tests/Git/ToolsCommands/GetCommitCountShould.cs
@@ -2,6 +2,7 @@
 using PrincipleStudios.ScaledGitApp.ShellUtilities;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -16,8 +17,21 @@ public class GetCommitCountShould
 	public async Task Get_commit_count_of_a_branch()
 	{
 		var included = new string[] { "main" };
-		var verifyGitClone = SetupGetCommitCount(fixture.MockPowerShell, included, [], 15);
+		var verifyGitClone = SetupGetCommitCount(fixture.MockPowerShell, included, [], 15, excludeMergeCommits: true);
 		var target = new GetCommitCount(included, []);
+
+		var actual = await target.Execute(fixture.Create());
+
+		Assert.Equal(15, actual);
+		verifyGitClone.Verify(Times.Once);
+	}
+
+	[Fact]
+	public async Task Get_commit_count_of_a_branch_including_merge_commits()
+	{
+		var included = new string[] { "main" };
+		var verifyGitClone = SetupGetCommitCount(fixture.MockPowerShell, included, [], 15, excludeMergeCommits: false);
+		var target = new GetCommitCount(included, [], ExcludeMergeCommits: false);
 
 		var actual = await target.Execute(fixture.Create());
 
@@ -29,8 +43,21 @@ public class GetCommitCountShould
 	public async Task Get_commit_count_of_multiple_branches()
 	{
 		var included = new string[] { "main", "feature/PS-123" };
-		var verifyGitClone = SetupGetCommitCount(fixture.MockPowerShell, included, [], 15);
+		var verifyGitClone = SetupGetCommitCount(fixture.MockPowerShell, included, [], 15, excludeMergeCommits: true);
 		var target = new GetCommitCount(included, []);
+
+		var actual = await target.Execute(fixture.Create());
+
+		Assert.Equal(15, actual);
+		verifyGitClone.Verify(Times.Once);
+	}
+
+	[Fact]
+	public async Task Get_commit_count_of_multiple_branches_including_merge_commits()
+	{
+		var included = new string[] { "main", "feature/PS-123" };
+		var verifyGitClone = SetupGetCommitCount(fixture.MockPowerShell, included, [], 15, excludeMergeCommits: false);
+		var target = new GetCommitCount(included, [], ExcludeMergeCommits: false);
 
 		var actual = await target.Execute(fixture.Create());
 
@@ -43,7 +70,7 @@ public class GetCommitCountShould
 	{
 		var included = new string[] { "feature/PS-123" };
 		var excluded = new string[] { "main" };
-		var verifyGitClone = SetupGetCommitCount(fixture.MockPowerShell, included, excluded, 1);
+		var verifyGitClone = SetupGetCommitCount(fixture.MockPowerShell, included, excluded, 1, excludeMergeCommits: true);
 		var target = new GetCommitCount(included, excluded);
 
 		var actual = await target.Execute(fixture.Create());
@@ -52,20 +79,36 @@ public class GetCommitCountShould
 		verifyGitClone.Verify(Times.Once);
 	}
 
-	internal static VerifiableMock<IPowerShellCommandContext, Task<PowerShellInvocationResult>> SetupGetCommitCount(Mock<IPowerShellCommandContext> target, string[] included, string[] excluded, int count)
+	[Fact]
+	public async Task Get_commit_count_excluding_branches_with_merge_commits()
+	{
+		var included = new string[] { "feature/PS-123" };
+		var excluded = new string[] { "main" };
+		var verifyGitClone = SetupGetCommitCount(fixture.MockPowerShell, included, excluded, 3, excludeMergeCommits: false);
+		var target = new GetCommitCount(included, excluded, ExcludeMergeCommits: false);
+
+		var actual = await target.Execute(fixture.Create());
+
+		Assert.Equal(3, actual);
+		verifyGitClone.Verify(Times.Once);
+	}
+
+	internal static VerifiableMock<IPowerShellCommandContext, Task<PowerShellInvocationResult>> SetupGetCommitCount(Mock<IPowerShellCommandContext> target, string[] included, string[] excluded, int count, bool excludeMergeCommits)
 	{
 		return target.Verifiable(
-			ps => ps.PowerShellInvoker.InvokeCliAsync("git", It.Is<string[]>(args => VerifyCliArgs(args, included, excluded))),
+			ps => ps.PowerShellInvoker.InvokeCliAsync("git", It.Is<string[]>(args => VerifyCliArgs(args, included, excluded, excludeMergeCommits))),
 			s => s.ReturnsAsync(PowerShellInvocationResultStubs.WithResults(count.ToString()))
 		);
 	}
 
-	static readonly string[] defaultSwitches = ["--count", "--no-merges"];
-	static bool VerifyCliArgs(string[] args, string[] included, string[] excluded)
+	static readonly string[] switchesWithoutMergeCommits = ["--count", "--no-merges"];
+	static readonly string[] switchesWithMergeCommits = ["--count"];
+	static bool VerifyCliArgs(string[] args, string[] included, string[] excluded, bool excludeMergeCommits)
 	{
 		if (args[0] != "rev-list") return false;
 		var argset = new HashSet<string>(args.Skip(1));
-		foreach (var s in defaultSwitches)
+		var switches = excludeMergeCommits ? switchesWithoutMergeCommits : switchesWithMergeCommits;
+		foreach (var s in switches)
 			if (!argset.Remove(s))
 				return false;
 		foreach (var s in included)

--- a/Server/Git/ToolsCommands/GetCommitCount.cs
+++ b/Server/Git/ToolsCommands/GetCommitCount.cs
@@ -2,12 +2,14 @@
 
 namespace PrincipleStudios.ScaledGitApp.Git.ToolsCommands;
 
-public record GetCommitCount(IEnumerable<string> Included, IEnumerable<string> Excluded) : IPowerShellCommand<Task<int?>>
+public record GetCommitCount(IEnumerable<string> Included, IEnumerable<string> Excluded, bool ExcludeMergeCommits = true) : IPowerShellCommand<Task<int?>>
 {
-	private static readonly IReadOnlyList<string> countArgs = ["rev-list", "--count", "--no-merges"];
+	private static readonly IReadOnlyList<string> countWithoutMergesArgs = ["rev-list", "--count", "--no-merges"];
+	private static readonly IReadOnlyList<string> countWithMergesArgs = ["rev-list", "--count"];
 
 	public async Task<int?> Execute(IPowerShellCommandContext context)
 	{
+		var countArgs = ExcludeMergeCommits ? countWithoutMergesArgs : countWithMergesArgs;
 		var cliResults = await context.InvokeCliAsync("git", countArgs.Concat(Included).Concat(Excluded.Select(b => $"^{b}")).ToArray());
 		if (cliResults.HadErrors) return null;
 		return int.Parse(cliResults.ToResultStrings().Single());

--- a/Server/Git/ToolsCommands/GitBranchUpstreamDetails.cs
+++ b/Server/Git/ToolsCommands/GitBranchUpstreamDetails.cs
@@ -79,7 +79,7 @@ public record GitBranchUpstreamDetails(string BranchName, bool IncludeDownstream
 				continue;
 			}
 
-			var behind = await context.Pwsh.RunCommand(new GetCommitCount(Included: [fullUpstream], Excluded: [fullBranchName]));
+			var behind = await context.Pwsh.RunCommand(new GetCommitCount(Included: [fullUpstream], Excluded: [fullBranchName], ExcludeMergeCommits: false));
 			entries.Add(new UpstreamBranchMergeInfo(
 				Name: shortUpstream,
 				Exists: behind.HasValue,


### PR DESCRIPTION
Previously, a merge commit be hidden from the upstream data, meaning the merge-base could get out of sync despite reporting that everything is up-to-date.