### PR TITLE
Add a config service to resolve branch names

### DIFF
--- a/Server/Git/GitConfigurationService.cs
+++ b/Server/Git/GitConfigurationService.cs
@@ -1,0 +1,22 @@
+﻿namespace PrincipleStudios.ScaledGitApp.Git;
+
+public sealed class GitConfigurationService(
+	Lazy<Task<GitCloneConfiguration>> gitCloneConfigurationAccessor
+) : IGitConfigurationService
+{
+	public GitConfigurationService(Func<Task<GitCloneConfiguration>> gitCloneConfiguration)
+		: this(new Lazy<Task<GitCloneConfiguration>>(gitCloneConfiguration))
+	{
+	}
+
+	public GitConfigurationService(GitCloneConfiguration gitCloneConfiguration)
+		: this(() => Task.FromResult(gitCloneConfiguration))
+	{
+	}
+
+	public async Task<string?> ToLocalTrackingBranchName(string remoteBranchName)
+	{
+		var config = await gitCloneConfigurationAccessor.Value;
+		return config.ToLocalTrackingBranchName(remoteBranchName);
+	}
+}

--- a/Server/Git/IGitConfigurationService.cs
+++ b/Server/Git/IGitConfigurationService.cs
@@ -1,0 +1,6 @@
+﻿namespace PrincipleStudios.ScaledGitApp.Git;
+
+public interface IGitConfigurationService
+{
+	Task<string?> ToLocalTrackingBranchName(string remoteBranchName);
+}

--- a/Server/Git/ServiceRegistration.cs
+++ b/Server/Git/ServiceRegistration.cs
@@ -18,6 +18,11 @@ public static class ServiceRegistration
 			var factory = () => sp.GetRequiredService<GitCloneService>().DetectedConfigurationTask;
 			return ActivatorUtilities.CreateInstance<GitToolsCommandInvoker>(sp, factory);
 		});
+		services.AddSingleton<IGitConfigurationService>(sp =>
+		{
+			var factory = () => sp.GetRequiredService<GitCloneService>().DetectedConfigurationTask;
+			return ActivatorUtilities.CreateInstance<GitConfigurationService>(sp, factory);
+		});
 		services.AddSingleton<IPowerShellCommandInvoker, PowerShellCommandInvoker>();
 	}
 }


### PR DESCRIPTION
Upcoming controllers need to resolve branch names to their local name before passing to commands so that commands can be consistent. 