### PR TITLE
Improve refresh button style

### DIFF
--- a/ui/src/components/common/icon-button.tsx
+++ b/ui/src/components/common/icon-button.tsx
@@ -1,0 +1,5 @@
+import { Button } from './button';
+
+export const IconButton = Button.extend('Button', (T) => (
+	<T className={'p-2 rounded-full text-xl w-auto'} />
+));

--- a/ui/src/components/common/index.tsx
+++ b/ui/src/components/common/index.tsx
@@ -1,4 +1,5 @@
 export * from './button';
+export * from './icon-button';
 export * from './container';
 export * from './InlineText';
 export * from './list';

--- a/ui/src/components/layout/header.presentation.tsx
+++ b/ui/src/components/layout/header.presentation.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { Button } from '../common';
+import { HiArrowPath } from 'react-icons/hi2';
+import { IconButton } from '../common';
 import { elementTemplate } from '../templating';
 import styles from './layout.module.css';
 
@@ -23,9 +24,16 @@ export function HeaderPresentation({ isRefreshing, onRefresh }: HeaderProps) {
 		<Header className={styles.header}>
 			<Link to="/">{t('title')}</Link>
 			<span className="flex-grow" />
-			<Button onClick={onRefresh} disabled={isRefreshing}>
-				{t('refresh')}
-			</Button>
+			<IconButton
+				title={t('refresh')}
+				onClick={onRefresh}
+				disabled={isRefreshing}
+			>
+				<HiArrowPath
+					title={t('refresh')}
+					className={isRefreshing ? 'animate-spin' : ''}
+				/>
+			</IconButton>
 		</Header>
 	);
 }


### PR DESCRIPTION
Adds a new `IconButton` component and uses it for the "Refresh" button in the header.

New style shown on left, old style on right:
![image](https://github.com/PrincipleStudios/ScaledGitApp/assets/144461/8855a945-ba65-4d98-820b-7574f64a66c3)
