### PR TITLE
Infra/branch listing reuse

### DIFF
--- a/ui/src/components/branch-listing/index.tsx
+++ b/ui/src/components/branch-listing/index.tsx
@@ -18,7 +18,7 @@ const branchListingSearchSchema = z.object({
 export type BranchItemProps = { branch: BranchConfiguration };
 
 export type BranchListingProps = {
-	children: (branches: BranchConfiguration[]) => JSX.Element;
+	children: (branches: BranchConfiguration[], query: string) => JSX.Element;
 };
 
 export function useBranchListing() {
@@ -70,7 +70,9 @@ function BranchListing({
 }: BranchListingProps & { branchNameAtom: Atom<string> }) {
 	const response = useSuspenseQuery(queries.getUpstreamData).data;
 	const branchName = useAtomValue(branchNameAtom);
-	if (branchName.length === 0) return null;
-	const branches = response.filter((r) => r.name.includes(branchName));
-	return children(branches);
+	const branches =
+		branchName.length === 0
+			? []
+			: response.filter((r) => r.name.includes(branchName));
+	return children(branches, branchName);
 }

--- a/ui/src/pages/overview/branch-link.tsx
+++ b/ui/src/pages/overview/branch-link.tsx
@@ -1,6 +1,11 @@
+import { BranchName } from '@/components/branch-display/BranchName';
 import type { BranchItemProps } from '@/components/branch-listing';
 import { Link } from '@/components/common';
 
 export function BranchLink({ branch }: BranchItemProps) {
-	return <Link to={`/branch?name=${branch.name}`}>{branch.name}</Link>;
+	return (
+		<Link to={`/branch?name=${branch.name}`}>
+			<BranchName data={branch} />
+		</Link>
+	);
 }

--- a/ui/src/pages/overview/branch-link.tsx
+++ b/ui/src/pages/overview/branch-link.tsx
@@ -1,0 +1,6 @@
+import type { BranchItemProps } from '@/components/branch-listing';
+import { Link } from '@/components/common';
+
+export function BranchLink({ branch }: BranchItemProps) {
+	return <Link to={`/branch?name=${branch.name}`}>{branch.name}</Link>;
+}

--- a/ui/src/pages/overview/index.tsx
+++ b/ui/src/pages/overview/index.tsx
@@ -1,12 +1,26 @@
 import { useBranchListing } from '@/components/branch-listing';
-import { Container } from '@/components/common';
+import { BulletList, Container, Section } from '@/components/common';
 import { BranchLink } from './branch-link';
 
 export function OverviewComponent() {
 	const BranchListing = useBranchListing();
 	return (
 		<Container.Flow>
-			<BranchListing branchItem={BranchLink} />
+			<Section.SingleColumn>
+				<BranchListing>
+					{(branches) => (
+						<Section.SingleColumn>
+							<BulletList>
+								{branches.map((b) => (
+									<BulletList.Item key={b.name}>
+										<BranchLink branch={b} />
+									</BulletList.Item>
+								))}
+							</BulletList>
+						</Section.SingleColumn>
+					)}
+				</BranchListing>
+			</Section.SingleColumn>
 		</Container.Flow>
 	);
 }

--- a/ui/src/pages/overview/index.tsx
+++ b/ui/src/pages/overview/index.tsx
@@ -1,11 +1,12 @@
+import { useBranchListing } from '@/components/branch-listing';
 import { Container } from '@/components/common';
-import { useBranchListing } from './branch-listing';
+import { BranchLink } from './branch-link';
 
 export function OverviewComponent() {
 	const BranchListing = useBranchListing();
 	return (
 		<Container.Flow>
-			<BranchListing />
+			<BranchListing branchItem={BranchLink} />
 		</Container.Flow>
 	);
 }


### PR DESCRIPTION
Make the "branch listing" component used on the homepage more reusable

This moves the concrete styles for the listing back out to the child so that only the form and querying is encapsulated, making it easier to reuse without assuming styles.