### PR TITLE
Include merge-tree result messages in API

### DIFF
--- a/Server.Tests/Git/ToolsCommands/GetConflictingFilesShould.cs
+++ b/Server.Tests/Git/ToolsCommands/GetConflictingFilesShould.cs
@@ -164,7 +164,7 @@ public class GetConflictingFilesShould
 		);
 	}
 
-	static readonly string[] defaultSwitches = ["-z"];
+	static readonly string[] defaultSwitches = ["-z", "--write-tree"];
 	static bool VerifyCliArgs(string[] args, string[] branches)
 	{
 		if (args[0] != "merge-tree") return false;

--- a/Server/Api/Git/GitDetectConflictsController.cs
+++ b/Server/Api/Git/GitDetectConflictsController.cs
@@ -33,7 +33,10 @@ public class GitDetectConflictsController(IGitToolsCommandInvoker gitToolsPowerS
 		// Determine if the named branches actually have conflicts
 		var conflicts = await conflictLocator.FindConflictsWithin(branches);
 
-		return GetConflictDetailsActionResult.Ok(conflicts.Select(conflict => ToConflictDetails(conflict, upstreams)));
+		return GetConflictDetailsActionResult.Ok(new ConflictAnalysis(
+			Branches: branches.Select(ToBranch),
+			Conflicts: conflicts.Select(conflict => ToConflictDetails(conflict, upstreams))
+		));
 	}
 
 	/// <summary>
@@ -75,7 +78,9 @@ public class GitDetectConflictsController(IGitToolsCommandInvoker gitToolsPowerS
 			Files: source.ConflictingFiles.ConflictingFiles.Select(ToFileDetails),
 			CandidateIntegrationBranch: from kvp in upstreams
 										where kvp.Value.UpstreamBranchNames.Count == 2 && kvp.Value.UpstreamBranchNames.All(source.Branches.Includes)
-										select ToBranch(kvp.Key)
+										select ToBranch(kvp.Key),
+			MergeTree: source.ConflictingFiles.ResultTreeHash,
+			Messages: source.ConflictingFiles.ConflictMessages.Select(m => m.Message)
 		);
 	}
 

--- a/Server/Git/ToolsCommands/GetConflictingFiles.cs
+++ b/Server/Git/ToolsCommands/GetConflictingFiles.cs
@@ -16,7 +16,7 @@ public record GetConflictingFiles(string LeftBranch, string RightBranch) : IPowe
 	private static readonly Regex fileInfoRegex = new(@"^(?<mode>[^ ]+) (?<hash>[^ ]+) (?<stage>[^\t]+)\t(?<path>.+)$");
 	public async Task<GetConflictingFilesResult> Execute(IPowerShellCommandContext context)
 	{
-		var cliResults = await context.InvokeCliAsync("git", "merge-tree", "-z", LeftBranch, RightBranch);
+		var cliResults = await context.InvokeCliAsync("git", "merge-tree", "-z", "--write-tree", LeftBranch, RightBranch);
 		var fullOutput = string.Join('\n', cliResults.ToResultStrings(allowErrors: true));
 		if (string.IsNullOrEmpty(fullOutput)) throw GitException.From(cliResults);
 		var entries = fullOutput.Split('\0').ToArray();

--- a/schemas/api.yaml
+++ b/schemas/api.yaml
@@ -142,9 +142,7 @@ paths:
           description: Conflict detection results
           content:
             application/json:
-              schema:
-                type: array
-                items: { $ref: '#/components/schemas/ConflictDetails' }
+              schema: { $ref: '#/components/schemas/ConflictAnalysis' }
         400:
           description: Bad Request
         409:
@@ -211,12 +209,26 @@ components:
         name: { type: string }
         color: { type: string }
         type: { type: string }
+    ConflictAnalysis:
+      type: object
+      required:
+        - branches
+        - conflicts
+      properties:
+        branches:
+          type: array
+          items: { $ref: '#/components/schemas/Branch' }
+        conflicts:
+          type: array
+          items: { $ref: '#/components/schemas/ConflictDetails' }
     ConflictDetails:
       type: object
       required:
         - branches
         - candidateIntegrationBranch
         - files
+        - mergeTree
+        - messages
       properties:
         branches:
           type: array
@@ -229,6 +241,11 @@ components:
           type: array
           minItems: 1
           items: { $ref: '#/components/schemas/FileConflictDetails' }
+        mergeTree:
+          type: string
+        messages:
+          type: array
+          items: { type: string }
     DetailedUpstreamBranch:
       type: object
       required:

--- a/ui/src/branch-actions/actions/inspect-conflicts.tsx
+++ b/ui/src/branch-actions/actions/inspect-conflicts.tsx
@@ -16,7 +16,7 @@ const provider: BranchActionProvider = {
 			);
 
 			// No conflicts!
-			if (conflictDetails.length === 0) return null;
+			if (conflictDetails.conflicts.length === 0) return null;
 
 			return {
 				actionKey: translationKey,


### PR DESCRIPTION
Update get-conflicts API to include the hash for the git tree that includes conflict markers for display.