### PR TITLE
Router parameter-binding refactor

### DIFF
--- a/ui/src/components/router/component-auto-binder.tsx
+++ b/ui/src/components/router/component-auto-binder.tsx
@@ -1,0 +1,29 @@
+type BindableProps<TPropName extends string, TValue> = {
+	[P in TPropName]?: TValue;
+};
+
+export type ComponentAutoBinder<TPropName extends string, TValue> = <
+	TProps extends BindableProps<TPropName, TValue>,
+>(
+	Component: React.ComponentType<TProps>,
+) => React.ComponentType<Omit<TProps, TPropName>>;
+
+export function componentAutoBinder<
+	const TPropName extends string,
+	const TValue,
+>(
+	prop: TPropName,
+	useValue: () => TValue,
+	displayNamePrefix: string,
+): ComponentAutoBinder<TPropName, TValue> {
+	return <TProps extends BindableProps<TPropName, TValue>>(
+		Component: React.ComponentType<TProps>,
+	) => {
+		function BoundComponent(props: Omit<TProps, TPropName>) {
+			const value = useValue();
+			return <Component {...({ ...props, [prop]: value } as TProps)} />;
+		}
+		BoundComponent.displayName = `${displayNamePrefix}(${prop})`;
+		return BoundComponent;
+	};
+}

--- a/ui/src/components/router/index.tsx
+++ b/ui/src/components/router/index.tsx
@@ -2,3 +2,4 @@ export * from './withErrorBoundary';
 export * from './withPathParamsValue';
 export * from './withSearchParamsValue';
 export * from './withParam';
+export type { ComponentAutoBinder } from './component-auto-binder';

--- a/ui/src/components/router/withParam.tsx
+++ b/ui/src/components/router/withParam.tsx
@@ -1,18 +1,11 @@
+import {
+	componentAutoBinder,
+	type ComponentAutoBinder,
+} from './component-auto-binder';
+
 export function withParam<const TPropName extends string, const TValue>(
 	prop: TPropName,
 	value: TValue,
-) {
-	return <
-		TProps extends {
-			[P in TPropName]: TValue;
-		},
-	>(
-		Component: React.ComponentType<TProps>,
-	): React.ComponentType<Omit<TProps, TPropName>> => {
-		function WithParams(props: Omit<TProps, TPropName>) {
-			return <Component {...({ ...props, [prop]: value } as TProps)} />;
-		}
-		WithParams.displayName = `WithParams(${prop})`;
-		return WithParams;
-	};
+): ComponentAutoBinder<TPropName, TValue> {
+	return componentAutoBinder(prop, () => value, 'WithParams');
 }

--- a/ui/src/components/router/withPathParamsValue.tsx
+++ b/ui/src/components/router/withPathParamsValue.tsx
@@ -1,25 +1,19 @@
 import { useParams } from 'react-router-dom';
+import {
+	componentAutoBinder,
+	type ComponentAutoBinder,
+} from './component-auto-binder';
 
 export function withPathParamsValue<const T extends string>(
 	prop: T,
 	pathParamName?: string,
-) {
-	return <
-		TProps extends {
-			[P in T]?: string | undefined;
-		},
-	>(
-		Component: React.ComponentType<TProps>,
-	): React.ComponentType<Omit<TProps, T>> => {
-		function WithParams(props: Omit<TProps, T>) {
+): ComponentAutoBinder<T, string | undefined> {
+	return componentAutoBinder(
+		prop,
+		function usePathParam() {
 			const params = useParams();
-			return (
-				<Component
-					{...({ ...props, [prop]: params[pathParamName ?? prop] } as TProps)}
-				/>
-			);
-		}
-		WithParams.displayName = `WithPathParams(${prop})`;
-		return WithParams;
-	};
+			return params[pathParamName ?? prop];
+		},
+		'WithPathParams',
+	);
 }

--- a/ui/src/components/router/withSearchParamsValue.tsx
+++ b/ui/src/components/router/withSearchParamsValue.tsx
@@ -1,20 +1,16 @@
 import { useSearchParams } from 'react-router-dom';
+import type { ComponentAutoBinder } from './component-auto-binder';
+import { componentAutoBinder } from './component-auto-binder';
 
-export function withSearchParamsValue<const T extends string>(prop: T) {
-	return <
-		TProps extends {
-			[P in T]: string[];
-		},
-	>(
-		Component: React.ComponentType<TProps>,
-	): React.ComponentType<Omit<TProps, T>> => {
-		function WithParams(props: Omit<TProps, T>) {
+export function withSearchParamsValue<const T extends string>(
+	prop: T,
+): ComponentAutoBinder<T, string[]> {
+	return componentAutoBinder(
+		prop,
+		function useSearchParam() {
 			const [params] = useSearchParams();
-			return (
-				<Component {...({ ...props, [prop]: params.getAll(prop) } as TProps)} />
-			);
-		}
-		WithParams.displayName = `WithParams(${prop})`;
-		return WithParams;
-	};
+			return params.getAll(prop);
+		},
+		'WithParams',
+	);
 }


### PR DESCRIPTION
I used a few utilities to make sure page components received parameters from the router via props rather than each one needing to use hooks. This PR refactors those to use a common `componentAutoBinder` function for easier reuse on each.