### PR TITLE
Improve conflict inspection

### DIFF
--- a/ui/src/branch-actions/actions/inspect-conflicts.tsx
+++ b/ui/src/branch-actions/actions/inspect-conflicts.tsx
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { BranchName } from '@/components/branch-display/BranchName';
 import { Link } from '@/components/common';
 import { Prose } from '@/components/text';
 import { queries } from '@/utils/api/queries';
@@ -39,20 +40,36 @@ function InspectConflicts({ branches }: ActionComponentProps) {
 		queries.getConflictDetails(branches.map((b) => b.name)),
 	).data;
 	const branchNames = branches.map((b) => b.name);
+	const integrationBranches = conflictDetails.conflicts.flatMap(
+		(c) => c.candidateIntegrationBranch,
+	);
 
 	return (
 		<>
 			<Prose>
-				{t('conflict-count', { count: conflictDetails.conflicts.length })}
+				{t('conflict-count', { count: conflictDetails.conflicts.length })}{' '}
+				&mdash;{' '}
+				<Link
+					to={{
+						pathname: '/branch/conflicts',
+						search: toSearchString({ name: branchNames }),
+					}}
+				>
+					{t('see-conflicts')}
+				</Link>
 			</Prose>
-			<Link
-				to={{
-					pathname: '/branch/conflicts',
-					search: toSearchString({ name: branchNames }),
-				}}
-			>
-				{t('see-conflicts')}
-			</Link>
+			{integrationBranches.length > 0 ? (
+				<>
+					<Prose>{t('integration-branches')}</Prose>
+					<ul>
+						{integrationBranches.map((b) => (
+							<li key={b.name}>
+								<BranchName data={b} />
+							</li>
+						))}
+					</ul>
+				</>
+			) : null}
 		</>
 	);
 }

--- a/ui/src/i18n/actions/en.json
+++ b/ui/src/i18n/actions/en.json
@@ -18,6 +18,7 @@
 		"description": "Conflicts have been detected with your branches (or between its upstreams).",
 		"see-conflicts": "See conflict details",
 		"conflict-count_one": "{{count}} conflict found",
-		"conflict-count_other": "{{count}} conflicts found"
+		"conflict-count_other": "{{count}} conflicts found",
+		"integration-branches": "Possible integration branches:"
 	}
 }

--- a/ui/src/i18n/branch-conflicts/en.json
+++ b/ui/src/i18n/branch-conflicts/en.json
@@ -9,11 +9,17 @@
 	"to-branch-graph": "Back to Branch Graph",
 	"inspect": {
 		"full-graph": "Original graph",
-		"list": "Showing conflicts for:",
+		"integrations-header": "Integration Branches",
+		"integrations-hint_one": "The following branch has an exact match of the conflicting branches; include this in the query to resolve this conflict.",
+		"integrations-hint_other": "The following branches have an exact match of the conflicting branches; include one of these in the query to resolve this conflict.",
 		"files-header": "Conflicting Files",
+		"conflict-index": "Conflict #{{index}}",
 		"fields": {
 			"filePath": {
 				"label": "Conflicting File"
+			},
+			"conflictIndex": {
+				"label": "Showing conflicts for:"
 			}
 		},
 		"to-graph": "View this conflict on the graph"

--- a/ui/src/i18n/branch-conflicts/en.json
+++ b/ui/src/i18n/branch-conflicts/en.json
@@ -23,5 +23,9 @@
 			}
 		},
 		"to-graph": "View this conflict on the graph"
+	},
+	"no-conflicts": {
+		"no-conflicts": "No conflicts were found with your current selection.",
+		"to-graph": "Back to the graph"
 	}
 }

--- a/ui/src/pages/branch-conflicts/NoConflicts.tsx
+++ b/ui/src/pages/branch-conflicts/NoConflicts.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from 'react-i18next';
+import { Container, Link, Section } from '@/components/common';
+import { Prose } from '@/components/text';
+import { toSearchString } from '@/utils/search-string';
+
+export function NoConflicts({ name }: { name: string[] }) {
+	const { t } = useTranslation('branch-conflicts', {
+		keyPrefix: 'no-conflicts',
+	});
+	return (
+		<Container.Flow>
+			<Section.SingleColumn>
+				<Prose>{t('no-conflicts')}</Prose>
+				<Link
+					to={{
+						pathname: `/branch`,
+						search: toSearchString({ name }),
+					}}
+				>
+					{t('to-graph')}
+				</Link>
+			</Section.SingleColumn>
+		</Container.Flow>
+	);
+}

--- a/ui/src/pages/branch-conflicts/components/ConflictSelector.tsx
+++ b/ui/src/pages/branch-conflicts/components/ConflictSelector.tsx
@@ -82,7 +82,7 @@ function useLocationAtom(atom: PrimitiveAtom<number>, selected: number) {
 	});
 	const store = useStore();
 	const actual = store.get(atom);
-	if (actual !== selected && selected) {
+	if (actual !== selected) {
 		setTimeout(() => store.set(atom, selected), 0);
 	}
 }

--- a/ui/src/pages/branch-conflicts/components/ConflictSelector.tsx
+++ b/ui/src/pages/branch-conflicts/components/ConflictSelector.tsx
@@ -3,7 +3,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useForm } from '@principlestudios/react-jotai-forms';
 import type { PrimitiveAtom } from 'jotai';
 import { useStore } from 'jotai';
-import { twMerge } from 'tailwind-merge';
 import { z } from 'zod';
 import { SelectField } from '@/components/form/select-field';
 import { translateField } from '@/components/form/utils/translations';

--- a/ui/src/pages/branch-conflicts/components/ConflictSelector.tsx
+++ b/ui/src/pages/branch-conflicts/components/ConflictSelector.tsx
@@ -72,10 +72,13 @@ function useLocationAtom(atom: PrimitiveAtom<number>, selected: number) {
 	// Ensure form and URL stay in sync
 	useAtomEffect(atom, (path) => {
 		if (selected === path) return;
-		navigate({
-			...location,
-			pathname: `/branch/conflicts/inspect/${path}`,
-		});
+		navigate(
+			{
+				...location,
+				pathname: `../inspect/${path}`,
+			},
+			{ relative: 'route' },
+		);
 	});
 	const store = useStore();
 	const actual = store.get(atom);

--- a/ui/src/pages/branch-conflicts/components/ConflictSelector.tsx
+++ b/ui/src/pages/branch-conflicts/components/ConflictSelector.tsx
@@ -1,0 +1,86 @@
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useForm } from '@principlestudios/react-jotai-forms';
+import type { PrimitiveAtom } from 'jotai';
+import { useStore } from 'jotai';
+import { twMerge } from 'tailwind-merge';
+import { z } from 'zod';
+import { SelectField } from '@/components/form/select-field';
+import { translateField } from '@/components/form/utils/translations';
+import { HintText } from '@/components/text';
+import type { ConflictAnalysis } from '@/generated/api/models';
+import { useAtomEffect } from '@/utils/atoms/useAtomEffect';
+import styles from '../inspect.module.css';
+import { BranchNamesList } from './BranchNamesList';
+
+export type ConflictSelectorProps = {
+	conflicts: ConflictAnalysis;
+	selected: string | undefined;
+};
+
+const filePathSelectorSchema = z.object({
+	conflictIndex: z.number().int(),
+});
+export function ConflictSelector({
+	conflicts,
+	selected,
+}: ConflictSelectorProps) {
+	const { t } = useTranslation('branch-conflicts', { keyPrefix: 'inspect' });
+	const selectedIndex = isNaN(Number(selected)) ? 0 : Number(selected);
+	const form = useForm({
+		schema: filePathSelectorSchema,
+		defaultValue: {
+			conflictIndex: selectedIndex,
+		},
+		fields: {
+			conflictIndex: ['conflictIndex'],
+		},
+	});
+
+	useLocationAtom(form.fields.conflictIndex.atom, selectedIndex);
+
+	return (
+		<div className={styles.conflictselector}>
+			{conflicts.conflicts.length === 1 ? (
+				<HintText className="mt-0 mb-2">
+					{translateField(form.fields.conflictIndex, t)(['label'])}
+				</HintText>
+			) : (
+				<SelectField
+					items={conflicts.conflicts.map((conflict, index) => index)}
+					translation={t}
+					field={form.fields.conflictIndex}
+				>
+					{(index) =>
+						t('conflict-index', {
+							replace: { index: (index + 1).toFixed(0) },
+						})
+					}
+				</SelectField>
+			)}
+
+			<div className="flex flex-col gap-2">
+				<BranchNamesList branches={conflicts.conflicts[0].branches} />
+			</div>
+		</div>
+	);
+}
+
+// Keeps the location path synced in this atom
+function useLocationAtom(atom: PrimitiveAtom<number>, selected: number) {
+	const navigate = useNavigate();
+	const location = useLocation();
+	// Ensure form and URL stay in sync
+	useAtomEffect(atom, (path) => {
+		if (selected === path) return;
+		navigate({
+			...location,
+			pathname: `/branch/conflicts/inspect/${path}`,
+		});
+	});
+	const store = useStore();
+	const actual = store.get(atom);
+	if (actual !== selected && selected) {
+		setTimeout(() => store.set(atom, selected), 0);
+	}
+}

--- a/ui/src/pages/branch-conflicts/components/FileList.tsx
+++ b/ui/src/pages/branch-conflicts/components/FileList.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import { HiArrowLeft } from 'react-icons/hi2';
 import { twMerge } from 'tailwind-merge';
 import { Link } from '@/components/common';
 import { Heading, HintText } from '@/components/text';
@@ -13,19 +12,7 @@ export function FileList({ conflict, selected }: FileSelectorProps) {
 	const location = useLocation();
 	const { t } = useTranslation('branch-conflicts', { keyPrefix: 'inspect' });
 	return (
-		<div
-			className={twMerge(
-				'py-4 pl-4 hidden max-h-full md:block overflow-auto',
-				styles.filelist,
-			)}
-		>
-			<Link to={{ ...location, pathname: `/graph` }}>
-				<HiArrowLeft className="inline-block" /> {t('full-graph')}
-			</Link>
-			<HintText className="mt-0 mb-2">{t('list')}</HintText>
-			<div className="flex flex-col gap-2">
-				<BranchNamesList branches={conflict.branches} />
-			</div>
+		<div className={twMerge('py-4 hidden md:block', styles.filelist)}>
 			<Link
 				to={{
 					pathname: `/branch`,
@@ -36,6 +23,21 @@ export function FileList({ conflict, selected }: FileSelectorProps) {
 			>
 				{t('to-graph')}
 			</Link>
+
+			{conflict.candidateIntegrationBranch.length ? (
+				<>
+					<Heading.Section className="my-4">
+						{t('integrations-header')}
+					</Heading.Section>
+					<HintText>
+						{t('integrations-hint', {
+							count: conflict.candidateIntegrationBranch.length,
+						})}
+					</HintText>
+					<BranchNamesList branches={conflict.candidateIntegrationBranch} />
+				</>
+			) : null}
+
 			<Heading.Section className="my-4">{t('files-header')}</Heading.Section>
 			<ul>
 				{conflict.files.map((f) => (

--- a/ui/src/pages/branch-conflicts/components/FileSelector.tsx
+++ b/ui/src/pages/branch-conflicts/components/FileSelector.tsx
@@ -54,10 +54,13 @@ function useLocationAtom(
 	// Ensure form and URL stay in sync
 	useAtomEffect(atom, (path) => {
 		if (selected === path) return;
-		navigate({
-			...location,
-			pathname: `./${path}`,
-		});
+		navigate(
+			{
+				...location,
+				pathname: `./${path}`,
+			},
+			{ relative: 'route' },
+		);
 	});
 	const store = useStore();
 	const actual = store.get(atom);

--- a/ui/src/pages/branch-conflicts/components/FileSelector.tsx
+++ b/ui/src/pages/branch-conflicts/components/FileSelector.tsx
@@ -33,7 +33,7 @@ export function FileSelector({ conflict, selected }: FileSelectorProps) {
 	useLocationAtom(form.fields.filePath.atom, selected);
 
 	return (
-		<div className={twMerge('p-4 md:hidden', styles.fileselector)}>
+		<div className={styles.fileselector}>
 			<SelectField
 				items={conflict.files.map((f) => f.path)}
 				translation={t}

--- a/ui/src/pages/branch-conflicts/components/FileSelector.tsx
+++ b/ui/src/pages/branch-conflicts/components/FileSelector.tsx
@@ -3,7 +3,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useForm } from '@principlestudios/react-jotai-forms';
 import type { PrimitiveAtom } from 'jotai';
 import { useStore } from 'jotai';
-import { twMerge } from 'tailwind-merge';
 import { z } from 'zod';
 import { SelectField } from '@/components/form/select-field';
 import type { ConflictDetails } from '@/generated/api/models';

--- a/ui/src/pages/branch-conflicts/index.tsx
+++ b/ui/src/pages/branch-conflicts/index.tsx
@@ -14,7 +14,10 @@ import { BranchConflictsSummary } from './summary';
 const withSearchParamsName = withSearchParamsValue('name');
 const branchConflictsSummary = withSearchParamsName(BranchConflictsSummary);
 const withFilePathSplat = withPathParamsValue('filePath', '*');
-const inspectConflictDetails = withFilePathSplat(InspectConflictDetails);
+const withIndex = withPathParamsValue('index');
+const inspectConflictDetails = withIndex(
+	withFilePathSplat(InspectConflictDetails),
+);
 
 export function BranchConflictsComponent({ name }: { name: string[] }) {
 	const conflictDetails = useSuspenseQuery(
@@ -23,14 +26,19 @@ export function BranchConflictsComponent({ name }: { name: string[] }) {
 
 	const route = useRoutes(
 		useMemo(
-			() => [
-				...conflictDetails.conflicts.flatMap((conflict, i): RouteObject[] => [
-					{
-						path: `/inspect/${i}/*`,
-						Component: withParam('conflict', conflict)(inspectConflictDetails),
-					},
-				]),
-				{ path: '*', Component: branchConflictsSummary },
+			(): RouteObject[] => [
+				{
+					path: `/inspect/:index/*`,
+					Component: withParam(
+						'conflicts',
+						conflictDetails,
+					)(inspectConflictDetails),
+				},
+				{ path: '/summary', Component: branchConflictsSummary },
+				{
+					path: '*',
+					element: <InspectConflictDetails conflicts={conflictDetails} />,
+				},
 			],
 			[conflictDetails],
 		),

--- a/ui/src/pages/branch-conflicts/index.tsx
+++ b/ui/src/pages/branch-conflicts/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { RouteObject } from 'react-router-dom';
-import { useRoutes } from 'react-router-dom';
+import { Navigate, useRoutes } from 'react-router-dom';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	withParam,
@@ -8,6 +8,7 @@ import {
 	withSearchParamsValue,
 } from '@/components/router';
 import { queries } from '@/utils/api/queries';
+import { toSearchString } from '@/utils/search-string';
 import { InspectConflictDetails } from './inspect';
 import { BranchConflictsSummary } from './summary';
 
@@ -24,6 +25,22 @@ export function BranchConflictsComponent({ name }: { name: string[] }) {
 		queries.getConflictDetails(name),
 	).data;
 
+	const defaultElement = useMemo(
+		() =>
+			conflictDetails.branches.length !== name.length ? (
+				<Navigate
+					to={{
+						search: toSearchString({
+							name: conflictDetails.branches.map((b) => b.name),
+						}),
+					}}
+				/>
+			) : (
+				<InspectConflictDetails conflicts={conflictDetails} />
+			),
+		[conflictDetails, name.length],
+	);
+
 	const route = useRoutes(
 		useMemo(
 			(): RouteObject[] => [
@@ -35,12 +52,9 @@ export function BranchConflictsComponent({ name }: { name: string[] }) {
 					)(inspectConflictDetails),
 				},
 				{ path: '/summary', Component: branchConflictsSummary },
-				{
-					path: '*',
-					element: <InspectConflictDetails conflicts={conflictDetails} />,
-				},
+				{ path: '*', element: defaultElement },
 			],
-			[conflictDetails],
+			[conflictDetails, defaultElement],
 		),
 	);
 

--- a/ui/src/pages/branch-conflicts/index.tsx
+++ b/ui/src/pages/branch-conflicts/index.tsx
@@ -10,6 +10,7 @@ import {
 import { queries } from '@/utils/api/queries';
 import { toSearchString } from '@/utils/search-string';
 import { InspectConflictDetails } from './inspect';
+import { NoConflicts } from './NoConflicts';
 import { BranchConflictsSummary } from './summary';
 
 const withSearchParamsName = withSearchParamsValue('name');
@@ -35,10 +36,18 @@ export function BranchConflictsComponent({ name }: { name: string[] }) {
 						}),
 					}}
 				/>
+			) : conflictDetails.conflicts.length > 0 ? (
+				<Navigate
+					to={{
+						pathname: './inspect/0',
+						search: toSearchString({ name }),
+					}}
+					relative="route"
+				/>
 			) : (
-				<InspectConflictDetails conflicts={conflictDetails} />
+				<NoConflicts name={name} />
 			),
-		[conflictDetails, name.length],
+		[conflictDetails, name],
 	);
 
 	const route = useRoutes(

--- a/ui/src/pages/branch-conflicts/inspect.module.css
+++ b/ui/src/pages/branch-conflicts/inspect.module.css
@@ -1,8 +1,21 @@
 
 .container {
-	grid-template-areas: 'fileselector' 'details';
-	grid-template-rows: auto 1fr;
+	grid-template-areas: 'conflictselector' 'fileselector' 'details';
+	grid-template-rows: auto auto 1fr;
 	grid-template-columns: 1fr;
+}
+
+.sidebar {
+	display: contents;
+}
+
+.sidebar > * {
+	padding-left: theme(space.4);
+	padding-right: theme(space.4);
+}
+
+.conflictselector {
+	grid-area: conflictselector;
 }
 
 .fileselector {
@@ -15,10 +28,19 @@
 
 @media screen(md) {
 	.container {
-		grid-template-areas: 'filelist details';
+		grid-template-areas: 'sidebar details';
 		grid-template-rows: 100%;
 		grid-template-columns: minmax(20vw, 200px) 1fr;
 	}
+
+	.sidebar {
+		display: initial;
+	}
+	.sidebar > * {
+		padding-left: 0;
+		padding-right: 0;
+	}
+	
 
 	.fileselector {
 		display: none;

--- a/ui/src/pages/branch-conflicts/inspect.tsx
+++ b/ui/src/pages/branch-conflicts/inspect.tsx
@@ -1,6 +1,11 @@
+import { useTranslation } from 'react-i18next';
+import { Navigate, useLocation } from 'react-router-dom';
+import { HiArrowLeft } from 'react-icons/hi2';
 import { twMerge } from 'tailwind-merge';
 import { Container } from '@/components/common';
-import type { ConflictDetails } from '@/generated/api/models';
+import { Link } from '@/components/common';
+import type { ConflictAnalysis } from '@/generated/api/models';
+import { ConflictSelector } from './components/ConflictSelector';
 import { FileList } from './components/FileList';
 import { FileSelector } from './components/FileSelector';
 import { ShowFileConflicts } from './components/ShowFileConflicts';
@@ -8,22 +13,37 @@ import { UnknownFile } from './components/UnknownFile';
 import styles from './inspect.module.css';
 
 export function InspectConflictDetails({
-	conflict,
+	conflicts,
+	index = '0',
 	filePath,
 }: {
-	conflict: ConflictDetails;
+	conflicts: ConflictAnalysis;
+	index?: string;
 	filePath?: string | undefined;
 }) {
+	const location = useLocation();
+	const { t } = useTranslation('branch-conflicts', { keyPrefix: 'inspect' });
+
+	const conflict = conflicts.conflicts[Number(index)];
 	const selectedFile =
-		conflict.files.find((f) => f.path === filePath) ?? conflict.files[0];
+		conflict?.files.find((f) => f.path === filePath) ?? conflict?.files[0];
+
+	if (!selectedFile)
+		return <Navigate to={{ ...location, pathname: './summary' }} />;
 
 	// TODO - don't use the summary, but instead use a monaco editor
 	return (
 		<Container.Responsive
 			className={twMerge('px-0 md:py-0 grid h-full', styles.container)}
 		>
-			<FileList conflict={conflict} selected={selectedFile?.path} />
-			<FileSelector conflict={conflict} selected={selectedFile?.path} />
+			<div className={twMerge('md:py-4 md:pl-4 overflow-auto', styles.sidebar)}>
+				<Link to={{ ...location, pathname: `/graph` }}>
+					<HiArrowLeft className="inline-block" /> {t('full-graph')}
+				</Link>
+				<ConflictSelector conflicts={conflicts} selected={index} />
+				<FileList conflict={conflict} selected={selectedFile?.path} />
+				<FileSelector conflict={conflict} selected={selectedFile?.path} />
+			</div>
 
 			{selectedFile ? (
 				<ShowFileConflicts


### PR DESCRIPTION
Improves display of conflicts, especially when there are more than one set of branches in the conflicts detected.

- Allows switching which set of conflicts is active via a Select component
- Improves layout for both mobile and desktop views
- When conflicts are detected from a single branch, redirects to a page that has only the detected upstream branches