### PR TITLE
Conflict detection updates: use integration branches

### DIFF
--- a/Server.Tests/Git/ToolsCommands/GitBranchUpstreamDetailsShould.cs
+++ b/Server.Tests/Git/ToolsCommands/GitBranchUpstreamDetailsShould.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using Moq.Language.Flow;
+using PrincipleStudios.ScaledGitApp.BranchingStrategy;
 
 namespace PrincipleStudios.ScaledGitApp.Git.ToolsCommands;
 
@@ -279,14 +280,14 @@ public class GitBranchUpstreamDetailsShould
 
 	private void SetupNoConflict(string branch1, string branch2)
 	{
-		fixture.PowerShellCommandInvoker.Setup(i => i.RunCommand(new GetConflictingFiles(ToFullName(branch1), ToFullName(branch2))))
-			.ReturnsAsync(new GetConflictingFilesResult(HasConflict: false, ResultTreeHash: "unused", [/*unused*/], [/*unused*/]));
+		fixture.PowerShellCommandInvoker.Setup(i => i.RunCommand(new GetConflictingFiles(ToFullName(branch1), ToFullName(branch2), null)))
+			.ReturnsAsync(new GetConflictingFilesResult(HasConflict: false, ResultTreeHash: "unused", [/*unused*/], [/*unused*/], BranchSet.Empty));
 	}
 
 	private void SetupConflict(string branch1, string branch2, string[] conflictingFileNames)
 	{
-		fixture.PowerShellCommandInvoker.Setup(i => i.RunCommand(new GetConflictingFiles(ToFullName(branch1), ToFullName(branch2))))
-			.ReturnsAsync(new GetConflictingFilesResult(HasConflict: true, ResultTreeHash: "unused", [/*unused*/], [/*unused*/]));
+		fixture.PowerShellCommandInvoker.Setup(i => i.RunCommand(new GetConflictingFiles(ToFullName(branch1), ToFullName(branch2), null)))
+			.ReturnsAsync(new GetConflictingFilesResult(HasConflict: true, ResultTreeHash: "unused", [/*unused*/], [/*unused*/], BranchSet.Empty));
 	}
 
 }

--- a/Server/Api/Git/GitDetectConflictsController.cs
+++ b/Server/Api/Git/GitDetectConflictsController.cs
@@ -1,7 +1,6 @@
 ﻿using PrincipleStudios.OpenApiCodegen.Json.Extensions;
 using PrincipleStudios.ScaledGitApp.Api.Git.Conversions;
 using PrincipleStudios.ScaledGitApp.BranchingStrategy;
-using PrincipleStudios.ScaledGitApp.Git;
 using PrincipleStudios.ScaledGitApp.Git.ToolsCommands;
 
 namespace PrincipleStudios.ScaledGitApp.Api.Git;
@@ -35,7 +34,9 @@ public class GitDetectConflictsController(IGitToolsCommandInvoker gitToolsPowerS
 
 		return GetConflictDetailsActionResult.Ok(new ConflictAnalysis(
 			Branches: branches.Select(ToBranch),
-			Conflicts: conflicts.Select(conflict => ToConflictDetails(conflict, upstreams))
+			Conflicts: from conflict in conflicts
+					   where conflict.ConflictingFiles.HasConflict
+					   select ToConflictDetails(conflict, upstreams)
 		));
 	}
 

--- a/Server/BranchingStrategy/BranchPair.cs
+++ b/Server/BranchingStrategy/BranchPair.cs
@@ -1,36 +1,13 @@
 ﻿namespace PrincipleStudios.ScaledGitApp.BranchingStrategy;
 
-public class BranchPair
+public class BranchPair : BranchSet
 {
-	public string LeftBranch { get; }
-	public string RightBranch { get; }
+	public string LeftBranch => Branches[0];
+	public string RightBranch => Branches[1];
 
-	public BranchPair(string leftBranch, string rightBranch)
+	public BranchPair(string leftBranch, string rightBranch) : base(leftBranch, rightBranch)
 	{
-		LeftBranch = leftBranch;
-		RightBranch = rightBranch;
 	}
-
-	public override bool Equals(object? obj)
-	{
-		if (obj == null) return false;
-		if (ReferenceEquals(this, obj)) return true;
-		if (obj.GetType() != GetType()) return false;
-		if (obj is not BranchPair other) return false;
-
-		if (other.LeftBranch == LeftBranch && other.RightBranch == RightBranch) return true;
-		if (other.LeftBranch == RightBranch && other.RightBranch == LeftBranch) return true;
-
-		return false;
-	}
-
-	public override int GetHashCode()
-	{
-		return LeftBranch.GetHashCode() ^ RightBranch.GetHashCode();
-	}
-
-	public bool Includes(string branch) =>
-		LeftBranch == branch || RightBranch == branch;
 
 	public string OtherBranch(string branch) =>
 		branch switch

--- a/Server/BranchingStrategy/BranchSet.cs
+++ b/Server/BranchingStrategy/BranchSet.cs
@@ -1,0 +1,40 @@
+﻿namespace PrincipleStudios.ScaledGitApp.BranchingStrategy;
+
+public class BranchSet
+{
+	public IReadOnlyList<string> Branches { get; }
+
+	public BranchSet(IEnumerable<string> branches)
+	{
+		Branches = branches.Distinct().ToArray().AsReadOnly();
+	}
+
+	public BranchSet(params string[] branches) : this((IEnumerable<string>)branches)
+	{
+	}
+
+	public override bool Equals(object? obj)
+	{
+		if (obj == null) return false;
+		if (ReferenceEquals(this, obj)) return true;
+		if (obj.GetType() != GetType()) return false;
+		if (obj is not BranchSet other) return false;
+
+		if (other.Branches.Count != Branches.Count) return false;
+		if (other.Branches.Except(Branches).Any()) return false;
+
+		return true;
+	}
+
+	public override int GetHashCode()
+	{
+		return Branches.Count == 0
+			? typeof(BranchSet).GetHashCode()
+			: Branches.Select(b => b.GetHashCode()).Aggregate((prev, next) => prev & next);
+	}
+
+	public bool Includes(string branch) =>
+		Branches.Contains(branch);
+
+	public static readonly BranchSet Empty = new BranchSet(Enumerable.Empty<string>());
+}

--- a/Server/BranchingStrategy/ConflictLocator.cs
+++ b/Server/BranchingStrategy/ConflictLocator.cs
@@ -43,7 +43,7 @@ public class ConflictLocator(IGitToolsCommandInvoker gitToolsPowerShell, IGitCon
 				await Task.Yield();
 
 				context.Results.Add(pair, [
-					new IdentifiedConflict(pair, GetConflictingFilesResult.Empty("TODO", [branches[i]]))
+					new IdentifiedConflict(pair, GetConflictingFilesResult.Empty("TODO", new BranchSet(branches[i])))
 				]);
 			}
 		}
@@ -81,7 +81,7 @@ public class ConflictLocator(IGitToolsCommandInvoker gitToolsPowerShell, IGitCon
 		var rightFullBranchName = await gitConfiguration.ToLocalTrackingBranchName(branchPair.RightBranch);
 		if (leftFullBranchName == null || rightFullBranchName == null) return returnValue;
 
-		var conflictResult = await gitToolsPowerShell.RunCommand(new GetConflictingFiles(leftFullBranchName, rightFullBranchName, []));
+		var conflictResult = await gitToolsPowerShell.RunCommand(new GetConflictingFiles(leftFullBranchName, rightFullBranchName));
 		if (!conflictResult.HasConflict) return returnValue;
 
 		var leftUpstream = context.GetImmediateUpstream(branchPair.LeftBranch);
@@ -95,7 +95,7 @@ public class ConflictLocator(IGitToolsCommandInvoker gitToolsPowerShell, IGitCon
 		else
 		{
 			// retry the conflicts including the helper integration branches
-			var includedIntegrationBranches = subConflicts.SelectMany(c => c.ConflictingFiles.IncludedIntegrationBranches).ToArray();
+			var includedIntegrationBranches = new BranchSet(subConflicts.SelectMany(c => c.ConflictingFiles.IncludedIntegrationBranches.Branches));
 			conflictResult = await gitToolsPowerShell.RunCommand(new GetConflictingFiles(leftFullBranchName, rightFullBranchName, includedIntegrationBranches));
 			result.Add(new(branchPair, conflictResult));
 		}

--- a/Server/Git/ToolsCommands/GetConflictingFiles.cs
+++ b/Server/Git/ToolsCommands/GetConflictingFiles.cs
@@ -1,10 +1,9 @@
-﻿using PrincipleStudios.ScaledGitApp.Api;
-using PrincipleStudios.ScaledGitApp.ShellUtilities;
+﻿using PrincipleStudios.ScaledGitApp.ShellUtilities;
 using System.Text.RegularExpressions;
 
 namespace PrincipleStudios.ScaledGitApp.Git.ToolsCommands;
 
-public record GetConflictingFiles(string LeftBranch, string RightBranch) : IPowerShellCommand<Task<GetConflictingFilesResult>>
+public class GetConflictingFiles(string LeftBranch, string RightBranch, IReadOnlyList<string>? HelpfulIntegrations = null) : IPowerShellCommand<Task<GetConflictingFilesResult>>
 {
 	// "stage" is a term used within git for merge information. From https://git-scm.com/docs/git-merge:
 	// stage 1 stores the version from the common ancestor, stage 2 from HEAD, and stage 3 from MERGE_HEAD
@@ -12,9 +11,49 @@ public record GetConflictingFiles(string LeftBranch, string RightBranch) : IPowe
 	const string leftStage = "2";
 	const string rightStage = "3";
 
+	private record WriteTreeResult(
+		bool HasConflict,
+		string ResultTreeHash,
+		IReadOnlyList<FileConflictDetails> ConflictingFiles,
+		IReadOnlyList<ConflictRecord> ConflictMessages
+	);
+
 	// mode ' ' hash ' ' stage '\t' path
 	private static readonly Regex fileInfoRegex = new(@"^(?<mode>[^ ]+) (?<hash>[^ ]+) (?<stage>[^\t]+)\t(?<path>.+)$");
+
 	public async Task<GetConflictingFilesResult> Execute(IPowerShellCommandContext context)
+	{
+		var usedIntegrationBranches = new List<string>();
+		var remainingIntegration = (HelpfulIntegrations ?? []).ToList();
+		var currentLeft = LeftBranch;
+		while (remainingIntegration.Count > 0)
+		{
+			var allFailed = true;
+			for (var i = 0; i < remainingIntegration.Count; i++)
+			{
+				var next = await WriteTree(context, currentLeft, remainingIntegration[i]);
+				if (next.HasConflict) continue;
+				allFailed = false;
+				currentLeft = await Commit(context, next.ResultTreeHash, [currentLeft, remainingIntegration[i]]);
+				usedIntegrationBranches.Add(remainingIntegration[i]);
+				remainingIntegration.Remove(remainingIntegration[i]);
+				i--;
+			}
+			if (allFailed) break;
+		}
+
+		var result = await WriteTree(context, currentLeft, RightBranch);
+
+		return new GetConflictingFilesResult(
+			result.HasConflict,
+			result.ResultTreeHash,
+			result.ConflictingFiles,
+			result.ConflictMessages,
+			usedIntegrationBranches.Order().ToArray().AsReadOnly()
+		);
+	}
+
+	private static async Task<WriteTreeResult> WriteTree(IPowerShellCommandContext context, string LeftBranch, string RightBranch)
 	{
 		var cliResults = await context.InvokeCliAsync("git", "merge-tree", "-z", "--write-tree", LeftBranch, RightBranch);
 		var fullOutput = string.Join('\n', cliResults.ToResultStrings(allowErrors: true));
@@ -45,12 +84,19 @@ public record GetConflictingFiles(string LeftBranch, string RightBranch) : IPowe
 			i += pathCount + 3;
 		}
 
-		return new GetConflictingFilesResult(
+		return new WriteTreeResult(
 			HasConflict: cliResults.HadErrors,
 			ResultTreeHash: treeHash,
 			ConflictingFiles: fileInfo,
 			ConflictMessages: conflictMessages.ToArray()
 		);
+	}
+
+	private static async Task<string> Commit(IPowerShellCommandContext context, string treeish, IReadOnlyList<string> commitishes)
+	{
+		var args = new[] { "commit-tree", treeish, "-m", "interim merge" }.Concat(commitishes.SelectMany(commitish => new[] { "-p", commitish })).ToArray();
+		var cliResults = await context.InvokeCliAsync("git", args);
+		return cliResults.ToResultStrings(allowErrors: false).Single();
 	}
 
 	private static FileConflictDetails ToFileConflictDetails(IGrouping<string, Match> grouping)
@@ -79,4 +125,18 @@ public record GetConflictingFiles(string LeftBranch, string RightBranch) : IPowe
 public record GitFileInfo(string Mode, string Hash);
 public record FileConflictDetails(string FilePath, GitFileInfo? MergeBase, GitFileInfo? Left, GitFileInfo? Right);
 public record ConflictRecord(IReadOnlyList<string> FilePaths, string ConflictType, string Message);
-public record GetConflictingFilesResult(bool HasConflict, string ResultTreeHash, IReadOnlyList<FileConflictDetails> ConflictingFiles, IReadOnlyList<ConflictRecord> ConflictMessages);
+public record GetConflictingFilesResult(
+	bool HasConflict,
+	string ResultTreeHash,
+	IReadOnlyList<FileConflictDetails> ConflictingFiles,
+	IReadOnlyList<ConflictRecord> ConflictMessages,
+	IReadOnlyList<string> IncludedIntegrationBranches)
+{
+	public static GetConflictingFilesResult Empty(string hash, IReadOnlyList<string> includedIntegrationBranches) => new GetConflictingFilesResult(
+		HasConflict: false,
+		ResultTreeHash: hash,
+		ConflictingFiles: [],
+		ConflictMessages: [],
+		IncludedIntegrationBranches: includedIntegrationBranches
+	);
+}


### PR DESCRIPTION
When an integration branch is selected for conflict detection, it should be used to resolve conflicts between other branches.

This PR:
- Generalizes the "branch pair" construct to a "branch set" construct
- Tries using integration branches to solve conflicts if they are included in the original request to detect conflicts
- Returns the merge-tree when conflicts are still found with the integration branches merged with the "left" branch